### PR TITLE
Add ChefMind frontend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+frontend/node_modules
+frontend/dist

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,17 @@
+# ChefMind Frontend
+
+This project is a simple admin dashboard for the imaginary ChefMind restaurant.
+It uses React, Tailwind CSS, and Supabase for authentication and database access.
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run the dev server:
+   ```bash
+   npm run dev
+   ```
+
+Make sure to configure the Supabase credentials in `.env`.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ChefMind</title>
+  </head>
+  <body class="bg-black text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "chefmind",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.38.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.2",
+    "vite": "^5.1.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react'
+import { supabase } from './supabase'
+
+function Auth({ onLogin }) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleLogin = async (e) => {
+    e.preventDefault()
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (!error) {
+      onLogin()
+    } else {
+      alert(error.message)
+    }
+  }
+
+  return (
+    <form onSubmit={handleLogin} className="p-4 space-y-2">
+      <input
+        className="text-black p-2"
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        className="text-black p-2"
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button className="bg-white text-black px-4 py-2" type="submit">Login</button>
+    </form>
+  )
+}
+
+function DataTable({ table }) {
+  const [items, setItems] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [form, setForm] = useState({})
+
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await supabase.from(table).select('*').order('created_at')
+      setItems(data)
+      setLoading(false)
+    }
+    load()
+  }, [table])
+
+  const addItem = async (e) => {
+    e.preventDefault()
+    await supabase.from(table).insert(form)
+    const { data } = await supabase.from(table).select('*').order('created_at')
+    setItems(data)
+    setForm({})
+  }
+
+  if (loading) return <p className="p-4">Loading...</p>
+
+  return (
+    <div className="p-4">
+      <form onSubmit={addItem} className="space-x-2 mb-4">
+        {Object.keys(items[0] || {}).filter(k => k !== 'id').map(key => (
+          <input
+            key={key}
+            className="text-black p-1"
+            placeholder={key}
+            value={form[key] || ''}
+            onChange={e => setForm({...form, [key]: e.target.value})}
+          />
+        ))}
+        <button className="bg-white text-black px-2" type="submit">Add</button>
+      </form>
+      <table className="table-auto border-collapse w-full">
+        <thead>
+          <tr>
+            {Object.keys(items[0] || {}).map(key => (
+              <th key={key} className="border px-2 py-1">{key}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {items.map(it => (
+            <tr key={it.id}>
+              {Object.keys(it).map(k => (
+                <td key={k} className="border px-2 py-1">{it[k]?.toString()}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+const tables = [
+  { name: 'Menu', table: 'menu_items' },
+  { name: 'Staff', table: 'staff' },
+  { name: 'Inventory', table: 'inventory' },
+  { name: 'Reports', table: 'daily_reports' },
+]
+
+function App() {
+  const [session, setSession] = useState(null)
+  const [tab, setTab] = useState(tables[0])
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session)
+    })
+    supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+    })
+  }, [])
+
+  if (!session) {
+    return <Auth onLogin={() => {}} />
+  }
+
+  return (
+    <div>
+      <nav className="flex space-x-4 p-4 bg-gray-800">
+        {tables.map(t => (
+          <button key={t.table} onClick={() => setTab(t)} className={tab.table === t.table ? 'underline' : ''}>
+            {t.name}
+          </button>
+        ))}
+      </nav>
+      <DataTable table={tab.table} />
+    </div>
+  )
+}
+
+export default App

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-black text-white;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/frontend/src/supabase.js
+++ b/frontend/src/supabase.js
@@ -1,0 +1,5 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+export const supabase = createClient(supabaseUrl, supabaseKey)

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- add skeleton React app in `/frontend`
- configure Tailwind and Vite
- include Supabase client setup and simple login/table UI
- document setup steps

## Testing
- `npm --prefix frontend install` *(fails: 403 Forbidden)*
- `npm --prefix frontend run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627e826164832fa64dc56b2343e341