### PR TITLE
Add King Dashboard page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { supabase } from './supabase'
+import KingDashboard from './pages/KingDashboard'
 
 function Auth({ onLogin }) {
   const [email, setEmail] = useState('')
@@ -106,13 +107,16 @@ const tables = [
 function App() {
   const [session, setSession] = useState(null)
   const [tab, setTab] = useState(tables[0])
+  const [isKing, setIsKing] = useState(false)
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       setSession(session)
+      setIsKing(session?.user?.user_metadata?.role === 'King')
     })
     supabase.auth.onAuthStateChange((_event, session) => {
       setSession(session)
+      setIsKing(session?.user?.user_metadata?.role === 'King')
     })
   }, [])
 
@@ -128,8 +132,17 @@ function App() {
             {t.name}
           </button>
         ))}
+        {isKing && (
+          <button onClick={() => setTab({ name: 'King', table: 'king' })} className={tab.table === 'king' ? 'underline' : ''}>
+            King
+          </button>
+        )}
       </nav>
-      <DataTable table={tab.table} />
+      {tab.table === 'king' ? (
+        <KingDashboard />
+      ) : (
+        <DataTable table={tab.table} />
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/KingDashboard.tsx
+++ b/frontend/src/pages/KingDashboard.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+export default function KingDashboard() {
+  // Placeholder role check. Replace with real auth logic when available
+  const hasAccess = true // This would check user role === 'King'
+  if (!hasAccess) {
+    return <p className="p-4">Access denied</p>
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-black via-[#2a0808] to-[#540b0e] p-6 text-yellow-300">
+      <h1 className="sr-only">Welcome back, your Majesty.</h1>
+      <p className="italic text-sm text-muted-foreground">
+        “ChefMind يعرف قبلك أين حدث الخطأ… لكنه ينتظرك لتكتشفه.”
+      </p>
+      <div className="mt-6 space-y-4">
+        <div className="bg-white/5 p-4 rounded">إجمالي الطلبات اليوم: <span className="font-bold">0</span></div>
+        <div className="bg-white/5 p-4 rounded">تنبيه فوري إذا نقص المخزون أو صار Waste عالي</div>
+        <div className="bg-white/5 p-4 rounded">عدد الساعات المهدورة من فريق العمل</div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create a new `KingDashboard` page
- show the page only for users with role `King`
- wire the dashboard into the main navigation

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628111e92c832faae2257764a8191a