### PR TITLE
Implement basic staff management

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,22 +1,16 @@
 import { useEffect, useState } from 'react'
-import { supabase, logKingAction } from './supabase'
+import { logKingAction } from './supabase'
+import Home from './pages/Home'
+import Reports from './pages/Reports'
 import KingDashboard from './pages/KingDashboard'
 
 function App() {
-  const [menu, setMenu] = useState([])
   const [isKing, setIsKing] = useState(() => {
     return localStorage.getItem('isKing') === 'true'
   })
   const [showModal, setShowModal] = useState(false)
   const [passwordInput, setPasswordInput] = useState('')
-
-  useEffect(() => {
-    async function fetchMenu() {
-      const { data } = await supabase.from('menu_items').select()
-      setMenu(data || [])
-    }
-    fetchMenu()
-  }, [])
+  const [page, setPage] = useState('home')
 
   useEffect(() => {
     localStorage.setItem('isKing', isKing)
@@ -39,12 +33,11 @@ function App() {
         </>
       ) : (
         <>
-          <h1 className='text-2xl font-bold mb-4 text-center text-red-700'>Welcome to ChefMind 👨‍🍳</h1>
-          <ul>
-            {menu.map(item => (
-              <li key={item.id}>{item.name} - {'$' + item.price}</li>
-            ))}
-          </ul>
+          {page === 'home' ? (
+            <Home onViewReports={() => setPage('reports')} />
+          ) : (
+            <Reports onBack={() => setPage('home')} />
+          )}
           <button
             className='fixed bottom-4 right-4 text-sm text-gray-400 underline'
             onClick={() => setShowModal(true)}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../supabase'
+
+export default function Home({ onViewReports }) {
+  const [staff, setStaff] = useState([])
+  const [showForm, setShowForm] = useState(false)
+  const [formData, setFormData] = useState({
+    name: '',
+    role: '',
+    shift: '',
+    status: ''
+  })
+
+  async function fetchStaff() {
+    const { data } = await supabase.from('staff').select()
+    setStaff(data || [])
+  }
+
+  useEffect(() => {
+    fetchStaff()
+  }, [])
+
+  async function addStaff(e) {
+    e.preventDefault()
+    await supabase.from('staff').insert(formData)
+    setFormData({ name: '', role: '', shift: '', status: '' })
+    setShowForm(false)
+    fetchStaff()
+  }
+
+  return (
+    <div className='space-y-4'>
+      <h2 className='text-xl font-bold'>Staff</h2>
+      <table className='w-full text-left border'>
+        <thead>
+          <tr className='border-b'>
+            <th className='p-2'>Name</th>
+            <th className='p-2'>Role</th>
+            <th className='p-2'>Shift</th>
+            <th className='p-2'>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {staff.map(s => (
+            <tr key={s.id} className='border-b'>
+              <td className='p-2'>{s.name}</td>
+              <td className='p-2'>{s.role}</td>
+              <td className='p-2'>{s.shift}</td>
+              <td className='p-2'>{s.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {showForm ? (
+        <form onSubmit={addStaff} className='space-y-2'>
+          <input
+            className='border p-1 w-full text-black'
+            placeholder='Name'
+            value={formData.name}
+            onChange={e => setFormData({ ...formData, name: e.target.value })}
+          />
+          <input
+            className='border p-1 w-full text-black'
+            placeholder='Role'
+            value={formData.role}
+            onChange={e => setFormData({ ...formData, role: e.target.value })}
+          />
+          <input
+            className='border p-1 w-full text-black'
+            placeholder='Shift'
+            value={formData.shift}
+            onChange={e => setFormData({ ...formData, shift: e.target.value })}
+          />
+          <input
+            className='border p-1 w-full text-black'
+            placeholder='Status'
+            value={formData.status}
+            onChange={e => setFormData({ ...formData, status: e.target.value })}
+          />
+          <div className='space-x-2'>
+            <button type='submit' className='border px-2 py-1'>Save</button>
+            <button type='button' className='border px-2 py-1' onClick={() => setShowForm(false)}>
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : (
+        <button className='border px-2 py-1' onClick={() => setShowForm(true)}>
+          Add Staff
+        </button>
+      )}
+      <button className='border px-2 py-1' onClick={onViewReports}>
+        View Reports
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/Reports.jsx
+++ b/frontend/src/pages/Reports.jsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../supabase'
+
+export default function Reports({ onBack }) {
+  const [reports, setReports] = useState([])
+  const [staff, setStaff] = useState([])
+  const [showForm, setShowForm] = useState(false)
+  const [formData, setFormData] = useState({
+    staff_id: '',
+    date: '',
+    shift: '',
+    notes: '',
+    issues: ''
+  })
+
+  async function fetchReports() {
+    const { data } = await supabase
+      .from('daily_reports')
+      .select('id, date, shift, notes, issues, staff_id, staff(name)')
+      .order('date', { ascending: false })
+    setReports(data || [])
+  }
+
+  async function fetchStaff() {
+    const { data } = await supabase.from('staff').select('id, name')
+    setStaff(data || [])
+  }
+
+  useEffect(() => {
+    fetchReports()
+    fetchStaff()
+  }, [])
+
+  async function addReport(e) {
+    e.preventDefault()
+    await supabase.from('daily_reports').insert({
+      staff_id: formData.staff_id,
+      date: formData.date,
+      shift: formData.shift,
+      notes: formData.notes,
+      issues: formData.issues
+    })
+    setFormData({ staff_id: '', date: '', shift: '', notes: '', issues: '' })
+    setShowForm(false)
+    fetchReports()
+  }
+
+  return (
+    <div className='space-y-4'>
+      <h2 className='text-xl font-bold'>Daily Reports</h2>
+      <table className='w-full text-left border'>
+        <thead>
+          <tr className='border-b'>
+            <th className='p-2'>Staff</th>
+            <th className='p-2'>Date</th>
+            <th className='p-2'>Shift</th>
+            <th className='p-2'>Notes</th>
+            <th className='p-2'>Issues</th>
+          </tr>
+        </thead>
+        <tbody>
+          {reports.map(r => (
+            <tr key={r.id} className='border-b'>
+              <td className='p-2'>{r.staff?.name}</td>
+              <td className='p-2'>{r.date}</td>
+              <td className='p-2'>{r.shift}</td>
+              <td className='p-2'>{r.notes}</td>
+              <td className='p-2'>{r.issues}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {showForm ? (
+        <form onSubmit={addReport} className='space-y-2'>
+          <select
+            className='border p-1 w-full text-black'
+            value={formData.staff_id}
+            onChange={e => setFormData({ ...formData, staff_id: e.target.value })}
+          >
+            <option value=''>Select Staff</option>
+            {staff.map(s => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+          <input
+            type='date'
+            className='border p-1 w-full text-black'
+            value={formData.date}
+            onChange={e => setFormData({ ...formData, date: e.target.value })}
+          />
+          <input
+            className='border p-1 w-full text-black'
+            placeholder='Shift'
+            value={formData.shift}
+            onChange={e => setFormData({ ...formData, shift: e.target.value })}
+          />
+          <textarea
+            className='border p-1 w-full text-black'
+            placeholder='Notes'
+            value={formData.notes}
+            onChange={e => setFormData({ ...formData, notes: e.target.value })}
+          />
+          <textarea
+            className='border p-1 w-full text-black'
+            placeholder='Issues'
+            value={formData.issues}
+            onChange={e => setFormData({ ...formData, issues: e.target.value })}
+          />
+          <div className='space-x-2'>
+            <button type='submit' className='border px-2 py-1'>Save</button>
+            <button type='button' className='border px-2 py-1' onClick={() => setShowForm(false)}>
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : (
+        <button className='border px-2 py-1' onClick={() => setShowForm(true)}>
+          Add Report
+        </button>
+      )}
+      <button className='border px-2 py-1' onClick={onBack}>Back</button>
+    </div>
+  )
+}

--- a/frontend/supabase-schema.sql
+++ b/frontend/supabase-schema.sql
@@ -1,0 +1,18 @@
+create table staff (
+  id uuid default uuid_generate_v4() primary key,
+  name text,
+  role text,
+  shift text,
+  status text,
+  created_at timestamp default now()
+);
+
+create table daily_reports (
+  id uuid default uuid_generate_v4() primary key,
+  date date,
+  shift text,
+  staff_id uuid references staff(id),
+  notes text,
+  issues text,
+  created_at timestamp default now()
+);


### PR DESCRIPTION
## Summary
- add staff and daily reports schema
- create Home page to manage staff
- create Reports page to record daily reports
- wire pages in `App.jsx`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68637a776288832fb0ffea065a750561