### PR TITLE
Add daily tasks management UI

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -11,10 +11,17 @@ It uses React, Tailwind CSS, and Supabase for authentication and database access
    ```
 2. Run the dev server:
    ```bash
-   npm run dev
-   ```
+ npm run dev
+  ```
 
 Make sure to configure the Supabase credentials in `.env`.
+
+### Daily Tasks
+
+Use the **Tasks** link in the sidebar to manage daily tasks. The table shows
+each task along with the assigned staff member, shift and status. The king can
+add new tasks or delete them, while other staff may only update the status of
+their own tasks.
 
 ### Royal Mode
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import Home from './pages/Home'
 import Reports from './pages/Reports'
 import KingDashboard from './pages/KingDashboard'
+import DailyTasks from './pages/DailyTasks'
 import Sidebar from './components/Sidebar'
 import Header from './components/Header'
 import { useRole } from './RoleContext'
@@ -15,6 +16,8 @@ function App() {
     content = <KingDashboard />
   } else if (page === 'reports') {
     content = <Reports onBack={() => setPage('home')} />
+  } else if (page === 'tasks') {
+    content = <DailyTasks />
   } else {
     content = <Home onViewReports={() => setPage('reports')} />
   }

--- a/frontend/src/RoleContext.jsx
+++ b/frontend/src/RoleContext.jsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState } from 'react'
 
-export const RoleContext = createContext({ role: null })
+export const RoleContext = createContext({ role: null, name: null })
 
 export function RoleProvider({ children }) {
   // TODO: later role should come from Supabase session
@@ -9,9 +9,10 @@ export function RoleProvider({ children }) {
     role: 'King',
   }
   const [role] = useState(currentUser.role)
+  const [name] = useState(currentUser.name)
 
   return (
-    <RoleContext.Provider value={{ role }}>
+    <RoleContext.Provider value={{ role, name }}>
       {children}
     </RoleContext.Provider>
   )

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -11,6 +11,9 @@ export default function Sidebar({ onNavigate }) {
       <button className="block" onClick={() => onNavigate('reports')}>
         Reports
       </button>
+      <button className="block" onClick={() => onNavigate('tasks')}>
+        Tasks
+      </button>
       {role === 'King' && (
         <button className="block" onClick={() => onNavigate('king')}>Admin Panel</button>
       )}

--- a/frontend/src/pages/DailyTasks.jsx
+++ b/frontend/src/pages/DailyTasks.jsx
@@ -1,0 +1,185 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../supabase'
+import { useRole } from '../RoleContext'
+
+export default function DailyTasks() {
+  const { role, name } = useRole()
+  const [tasks, setTasks] = useState([])
+  const [staff, setStaff] = useState([])
+  const [showForm, setShowForm] = useState(false)
+  const [formData, setFormData] = useState({ task: '', shift: '', staff_id: '' })
+  const [filters, setFilters] = useState({ shift: '', status: '', staff_id: '' })
+
+  useEffect(() => {
+    fetchStaff()
+  }, [])
+
+  useEffect(() => {
+    fetchTasks()
+  }, [filters])
+
+  async function fetchTasks() {
+    let query = supabase
+      .from('daily_tasks')
+      .select('id, task, shift, status, created_at, staff(name)')
+      .order('created_at', { ascending: false })
+    if (filters.shift) query = query.eq('shift', filters.shift)
+    if (filters.status) query = query.eq('status', filters.status)
+    if (filters.staff_id) query = query.eq('staff_id', filters.staff_id)
+    const { data } = await query
+    setTasks(data || [])
+  }
+
+  async function fetchStaff() {
+    const { data } = await supabase.from('staff').select('id, name')
+    setStaff(data || [])
+  }
+
+  async function addTask(e) {
+    e.preventDefault()
+    await supabase.from('daily_tasks').insert({
+      task: formData.task,
+      shift: formData.shift,
+      staff_id: formData.staff_id,
+      status: 'pending',
+    })
+    setFormData({ task: '', shift: '', staff_id: '' })
+    setShowForm(false)
+    fetchTasks()
+  }
+
+  async function updateStatus(id, status) {
+    await supabase.from('daily_tasks').update({ status }).eq('id', id)
+    fetchTasks()
+  }
+
+  async function deleteTask(id) {
+    await supabase.from('daily_tasks').delete().eq('id', id)
+    fetchTasks()
+  }
+
+  const canEdit = role === 'King'
+
+  return (
+    <div className="space-y-4 text-[#FFD700]">
+      <h2 className="text-xl font-bold">Daily Tasks</h2>
+      <div className="space-x-2">
+        <select
+          className="border border-[#800000] bg-black text-[#FFD700] p-1"
+          value={filters.shift}
+          onChange={e => setFilters({ ...filters, shift: e.target.value })}
+        >
+          <option value="">All Shifts</option>
+          <option value="Morning">Morning</option>
+          <option value="Evening">Evening</option>
+          <option value="Double">Double</option>
+        </select>
+        <select
+          className="border border-[#800000] bg-black text-[#FFD700] p-1"
+          value={filters.status}
+          onChange={e => setFilters({ ...filters, status: e.target.value })}
+        >
+          <option value="">All Statuses</option>
+          <option value="pending">Pending</option>
+          <option value="done">Done</option>
+          <option value="skipped">Skipped</option>
+        </select>
+        <select
+          className="border border-[#800000] bg-black text-[#FFD700] p-1"
+          value={filters.staff_id}
+          onChange={e => setFilters({ ...filters, staff_id: e.target.value })}
+        >
+          <option value="">All Staff</option>
+          {staff.map(s => (
+            <option key={s.id} value={s.id}>{s.name}</option>
+          ))}
+        </select>
+      </div>
+      <table className="w-full text-left border border-[#800000]">
+        <thead>
+          <tr className="border-b border-[#800000]">
+            <th className="p-2">Task</th>
+            <th className="p-2">Shift</th>
+            <th className="p-2">Status</th>
+            <th className="p-2">Staff</th>
+            <th className="p-2">Created</th>
+            {canEdit && <th className="p-2">Actions</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {tasks.map(t => (
+            <tr key={t.id} className="border-b border-[#800000]">
+              <td className="p-2">{t.task}</td>
+              <td className="p-2">{t.shift}</td>
+              <td className="p-2">
+                {(canEdit || t.staff?.name === name) ? (
+                  <select
+                    className="border border-[#800000] bg-black text-[#FFD700]"
+                    value={t.status}
+                    onChange={e => updateStatus(t.id, e.target.value)}
+                  >
+                    <option value="pending">pending</option>
+                    <option value="done">done</option>
+                    <option value="skipped">skipped</option>
+                  </select>
+                ) : (
+                  t.status
+                )}
+              </td>
+              <td className="p-2">{t.staff?.name}</td>
+              <td className="p-2">{new Date(t.created_at).toLocaleString()}</td>
+              {canEdit && (
+                <td className="p-2">
+                  <button
+                    className="border border-[#800000] px-2 mr-1"
+                    onClick={() => deleteTask(t.id)}
+                  >
+                    Delete
+                  </button>
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {canEdit && (
+        showForm ? (
+          <form onSubmit={addTask} className="space-y-2">
+            <input
+              className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+              placeholder="Task"
+              value={formData.task}
+              onChange={e => setFormData({ ...formData, task: e.target.value })}
+            />
+            <select
+              className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+              value={formData.shift}
+              onChange={e => setFormData({ ...formData, shift: e.target.value })}
+            >
+              <option value="">Select Shift</option>
+              <option value="Morning">Morning</option>
+              <option value="Evening">Evening</option>
+              <option value="Double">Double</option>
+            </select>
+            <select
+              className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+              value={formData.staff_id}
+              onChange={e => setFormData({ ...formData, staff_id: e.target.value })}
+            >
+              <option value="">Select Staff</option>
+              {staff.map(s => (
+                <option key={s.id} value={s.id}>{s.name}</option>
+              ))}
+            </select>
+            <div className="space-x-2">
+              <button type="submit" className="border border-[#800000] px-2 py-1">Save</button>
+              <button type="button" className="border border-[#800000] px-2 py-1" onClick={() => setShowForm(false)}>Cancel</button>
+            </div>
+          </form>
+        ) : (
+          <button className="border border-[#800000] px-2 py-1" onClick={() => setShowForm(true)}>Add Task</button>
+        )
+      )}
+    </div>
+  )
+}

--- a/frontend/supabase-schema.sql
+++ b/frontend/supabase-schema.sql
@@ -16,3 +16,12 @@ create table daily_reports (
   issues text,
   created_at timestamp default now()
 );
+
+create table daily_tasks (
+  id uuid default uuid_generate_v4() primary key,
+  task text,
+  shift text,
+  status text default 'pending',
+  staff_id uuid references staff(id),
+  created_at timestamp default now()
+);


### PR DESCRIPTION
## Summary
- add `DailyTasks` page to manage daily tasks with filtering and status updates
- expose staff `name` via `RoleContext`
- link tasks page through `Sidebar` and handle in `App`
- document tasks page and extend Supabase schema

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68638191e500832f946633fd2dc48b9f