### PR TITLE
Add frontend alerts system

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import Home from './pages/Home'
 import Reports from './pages/Reports'
+import Alerts from './pages/Alerts'
 import KingDashboard from './pages/KingDashboard'
 import Sidebar from './components/Sidebar'
 import Header from './components/Header'
@@ -15,6 +16,8 @@ function App() {
     content = <KingDashboard />
   } else if (page === 'reports') {
     content = <Reports onBack={() => setPage('home')} />
+  } else if (page === 'alerts') {
+    content = <Alerts />
   } else {
     content = <Home onViewReports={() => setPage('reports')} />
   }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -11,6 +11,9 @@ export default function Sidebar({ onNavigate }) {
       <button className="block" onClick={() => onNavigate('reports')}>
         Reports
       </button>
+      <button className="block" onClick={() => onNavigate('alerts')}>
+        Alerts
+      </button>
       {role === 'King' && (
         <button className="block" onClick={() => onNavigate('king')}>Admin Panel</button>
       )}

--- a/frontend/src/pages/Alerts.jsx
+++ b/frontend/src/pages/Alerts.jsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../supabase'
+import { useRole } from '../RoleContext'
+
+export default function Alerts() {
+  const { role } = useRole()
+  const [alerts, setAlerts] = useState([])
+
+  async function fetchAlerts() {
+    // fetch dismissed alerts
+    const { data: dismissedData } = await supabase
+      .from('dismissed_alerts')
+      .select('message')
+    const dismissed = dismissedData ? dismissedData.map(d => d.message) : []
+
+    // inventory alerts
+    const { data: inv } = await supabase
+      .from('inventory')
+      .select('id, name, updated_at')
+      .eq('low_stock_alert', true)
+    const invAlerts = (inv || []).map(i => ({
+      id: `inv-${i.id}`,
+      message: `${i.name} is running low!`,
+      type: 'Stock',
+      created_at: i.updated_at || new Date().toISOString(),
+    }))
+
+    // staff alerts
+    const { data: staff } = await supabase
+      .from('staff')
+      .select('id, name, role, status, updated_at')
+      .neq('status', 'Active')
+    const staffAlerts = (staff || []).map(s => ({
+      id: `staff-${s.id}`,
+      message: `${s.name} (${s.role}) is marked as inactive.`,
+      type: 'Staff',
+      created_at: s.updated_at || new Date().toISOString(),
+    }))
+
+    // task alerts
+    const nowIso = new Date().toISOString()
+    const { data: tasks } = await supabase
+      .from('daily_tasks')
+      .select('id, task, due, updated_at')
+      .eq('status', 'pending')
+      .lt('due', nowIso)
+    const taskAlerts = (tasks || []).map(t => ({
+      id: `task-${t.id}`,
+      message: `${t.task} – still pending since ${t.due}.`,
+      type: 'Task',
+      created_at: t.updated_at || t.due,
+    }))
+
+    const all = [...invAlerts, ...staffAlerts, ...taskAlerts]
+      .filter(a => !dismissed.includes(a.message))
+      .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+    setAlerts(all)
+  }
+
+  async function dismissAlert(alert) {
+    await supabase.from('dismissed_alerts').insert({ message: alert.message })
+    fetchAlerts()
+  }
+
+  useEffect(() => {
+    fetchAlerts()
+  }, [])
+
+  return (
+    <div className='space-y-4'>
+      <h2 className='text-xl font-bold'>Alerts</h2>
+      <div className='space-y-2'>
+        {alerts.map(a => (
+          <div key={a.id} className='border p-3 flex justify-between'>
+            <div>
+              <div className='font-semibold'>{a.message}</div>
+              <div className='text-sm text-gray-400'>
+                {a.type} – {new Date(a.created_at).toLocaleString()}
+              </div>
+            </div>
+            {role === 'King' && (
+              <button
+                className='border px-2 py-1'
+                onClick={() => dismissAlert(a)}
+              >
+                Dismiss
+              </button>
+            )}
+          </div>
+        ))}
+        {alerts.length === 0 && <div>No alerts at this time.</div>}
+      </div>
+    </div>
+  )
+}

--- a/frontend/supabase-schema.sql
+++ b/frontend/supabase-schema.sql
@@ -16,3 +16,9 @@ create table daily_reports (
   issues text,
   created_at timestamp default now()
 );
+
+create table dismissed_alerts (
+  id uuid default uuid_generate_v4() primary key,
+  message text,
+  created_at timestamp default now()
+);


### PR DESCRIPTION
## Summary
- create `Alerts` page to show low stock, inactive staff, and overdue task alerts
- add dismiss feature storing messages in new `dismissed_alerts` table
- integrate alerts navigation and page rendering
- document new `dismissed_alerts` table in schema

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863895d6940832f8b73ce4d0b52e050