### PR TITLE
Add staff management page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import Home from './pages/Home'
 import Reports from './pages/Reports'
 import KingDashboard from './pages/KingDashboard'
 import DailyTasks from './pages/DailyTasks'
+import StaffPage from './pages/StaffPage'
 import Sidebar from './components/Sidebar'
 import Header from './components/Header'
 import { useRole } from './RoleContext'
@@ -18,6 +19,8 @@ function App() {
     content = <Reports onBack={() => setPage('home')} />
   } else if (page === 'tasks') {
     content = <DailyTasks />
+  } else if (page === 'staff') {
+    content = <StaffPage />
   } else {
     content = <Home onViewReports={() => setPage('reports')} />
   }

--- a/frontend/src/components/AddStaffModal.jsx
+++ b/frontend/src/components/AddStaffModal.jsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import { addStaff } from '../supabase/staff'
+
+export default function AddStaffModal({ isOpen, onClose, onAdded }) {
+  const [form, setForm] = useState({ name: '', role: '', shift: '', status: '' })
+
+  if (!isOpen) return null
+
+  function handleChange(e) {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    await addStaff(form)
+    onAdded()
+    setForm({ name: '', role: '', shift: '', status: '' })
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <div className="bg-gray-800 p-4 rounded space-y-2 w-72">
+        <h3 className="text-lg text-[#FFD700]">Add Staff</h3>
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <input
+            className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            placeholder="Name"
+            name="name"
+            value={form.name}
+            onChange={handleChange}
+          />
+          <input
+            className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            placeholder="Role"
+            name="role"
+            value={form.role}
+            onChange={handleChange}
+          />
+          <input
+            className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            placeholder="Shift"
+            name="shift"
+            value={form.shift}
+            onChange={handleChange}
+          />
+          <input
+            className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            placeholder="Status"
+            name="status"
+            value={form.status}
+            onChange={handleChange}
+          />
+          <div className="space-x-2">
+            <button type="submit" className="border border-[#800000] px-2 py-1">Save</button>
+            <button type="button" className="border border-[#800000] px-2 py-1" onClick={onClose}>
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/EditStaffModal.jsx
+++ b/frontend/src/components/EditStaffModal.jsx
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react'
+import { updateStaff } from '../supabase/staff'
+
+export default function EditStaffModal({ isOpen, staff, onClose, onUpdated }) {
+  const [form, setForm] = useState({ name: '', role: '', shift: '', status: '' })
+
+  useEffect(() => {
+    if (staff) {
+      setForm({
+        name: staff.name || '',
+        role: staff.role || '',
+        shift: staff.shift || '',
+        status: staff.status || '',
+      })
+    }
+  }, [staff])
+
+  if (!isOpen || !staff) return null
+
+  function handleChange(e) {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    await updateStaff(staff.id, form)
+    onUpdated()
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <div className="bg-gray-800 p-4 rounded space-y-2 w-72">
+        <h3 className="text-lg text-[#FFD700]">Edit Staff</h3>
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <input
+            className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            placeholder="Name"
+            name="name"
+            value={form.name}
+            onChange={handleChange}
+          />
+          <input
+            className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            placeholder="Role"
+            name="role"
+            value={form.role}
+            onChange={handleChange}
+          />
+          <input
+            className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            placeholder="Shift"
+            name="shift"
+            value={form.shift}
+            onChange={handleChange}
+          />
+          <input
+            className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            placeholder="Status"
+            name="status"
+            value={form.status}
+            onChange={handleChange}
+          />
+          <div className="space-x-2">
+            <button type="submit" className="border border-[#800000] px-2 py-1">Save</button>
+            <button type="button" className="border border-[#800000] px-2 py-1" onClick={onClose}>Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -11,6 +11,9 @@ export default function Sidebar({ onNavigate }) {
       <button className="block" onClick={() => onNavigate('reports')}>
         Reports
       </button>
+      <button className="block" onClick={() => onNavigate('staff')}>
+        Staff
+      </button>
       <button className="block" onClick={() => onNavigate('tasks')}>
         Tasks
       </button>

--- a/frontend/src/components/StaffTable.jsx
+++ b/frontend/src/components/StaffTable.jsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react'
+import { getStaff, deleteStaff } from '../supabase/staff'
+import AddStaffModal from './AddStaffModal'
+import EditStaffModal from './EditStaffModal'
+import { useRole } from '../RoleContext'
+
+export default function StaffTable() {
+  const { role } = useRole()
+  const [staff, setStaff] = useState([])
+  const [filters, setFilters] = useState({ shift: '', role: '', status: '' })
+  const [showAdd, setShowAdd] = useState(false)
+  const [editItem, setEditItem] = useState(null)
+
+  useEffect(() => {
+    fetchStaff()
+  }, [filters])
+
+  async function fetchStaff() {
+    const data = await getStaff(filters)
+    setStaff(data || [])
+  }
+
+  async function handleDelete(id) {
+    if (!confirm('Delete this staff member?')) return
+    await deleteStaff(id)
+    fetchStaff()
+  }
+
+  const roles = Array.from(new Set(staff.map(s => s.role).filter(Boolean)))
+  const shifts = Array.from(new Set(staff.map(s => s.shift).filter(Boolean)))
+  const statuses = Array.from(new Set(staff.map(s => s.status).filter(Boolean)))
+
+  return (
+    <div className="space-y-2">
+      <div className="space-x-2">
+        <select
+          className="border border-[#800000] bg-black text-[#FFD700] p-1"
+          value={filters.shift}
+          onChange={e => setFilters({ ...filters, shift: e.target.value })}
+        >
+          <option value="">All Shifts</option>
+          {shifts.map(sh => (
+            <option key={sh} value={sh}>{sh}</option>
+          ))}
+        </select>
+        <select
+          className="border border-[#800000] bg-black text-[#FFD700] p-1"
+          value={filters.role}
+          onChange={e => setFilters({ ...filters, role: e.target.value })}
+        >
+          <option value="">All Roles</option>
+          {roles.map(r => (
+            <option key={r} value={r}>{r}</option>
+          ))}
+        </select>
+        <select
+          className="border border-[#800000] bg-black text-[#FFD700] p-1"
+          value={filters.status}
+          onChange={e => setFilters({ ...filters, status: e.target.value })}
+        >
+          <option value="">All Statuses</option>
+          {statuses.map(s => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+        <button
+          className="border border-[#800000] px-2 py-1"
+          onClick={() => setShowAdd(true)}
+        >
+          Add Staff
+        </button>
+      </div>
+      <table className="w-full text-left border border-[#800000]">
+        <thead>
+          <tr className="border-b border-[#800000]">
+            <th className="p-2">Name</th>
+            <th className="p-2">Role</th>
+            <th className="p-2">Shift</th>
+            <th className="p-2">Status</th>
+            <th className="p-2">Created</th>
+            <th className="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {staff.map(s => (
+            <tr key={s.id} className="border-b border-[#800000]">
+              <td className="p-2">{s.name}</td>
+              <td className="p-2">{s.role}</td>
+              <td className="p-2">{s.shift}</td>
+              <td className="p-2">{s.status}</td>
+              <td className="p-2">{new Date(s.created_at).toLocaleString()}</td>
+              <td className="p-2 space-x-1">
+                <button
+                  className="border border-[#800000] px-1"
+                  onClick={() => setEditItem(s)}
+                >
+                  Edit
+                </button>
+                {role === 'King' && (
+                  <button
+                    className="border border-[#800000] px-1"
+                    onClick={() => handleDelete(s.id)}
+                  >
+                    Delete
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <AddStaffModal
+        isOpen={showAdd}
+        onClose={() => setShowAdd(false)}
+        onAdded={fetchStaff}
+      />
+      <EditStaffModal
+        isOpen={!!editItem}
+        staff={editItem}
+        onClose={() => setEditItem(null)}
+        onUpdated={fetchStaff}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/StaffPage.jsx
+++ b/frontend/src/pages/StaffPage.jsx
@@ -1,0 +1,10 @@
+import StaffTable from '../components/StaffTable'
+
+export default function StaffPage() {
+  return (
+    <div className="space-y-4 text-[#FFD700]">
+      <h2 className="text-xl font-bold">Staff Members</h2>
+      <StaffTable />
+    </div>
+  )
+}

--- a/frontend/src/supabase/staff.js
+++ b/frontend/src/supabase/staff.js
@@ -1,0 +1,37 @@
+import { supabase } from '../supabase'
+
+export async function getStaff(filters = {}) {
+  let query = supabase.from('staff').select('*').order('created_at', { ascending: false })
+  if (filters.shift) query = query.eq('shift', filters.shift)
+  if (filters.role) query = query.eq('role', filters.role)
+  if (filters.status) query = query.eq('status', filters.status)
+  const { data, error } = await query
+  if (error) throw error
+  return data
+}
+
+export async function addStaff(data) {
+  const { data: result, error } = await supabase
+    .from('staff')
+    .insert(data)
+    .select()
+    .single()
+  if (error) throw error
+  return result
+}
+
+export async function updateStaff(id, data) {
+  const { data: result, error } = await supabase
+    .from('staff')
+    .update(data)
+    .eq('id', id)
+    .select()
+    .single()
+  if (error) throw error
+  return result
+}
+
+export async function deleteStaff(id) {
+  const { error } = await supabase.from('staff').delete().eq('id', id)
+  if (error) throw error
+}


### PR DESCRIPTION
## Summary
- implement CRUD helpers for staff in Supabase
- create modals for adding and editing staff
- create dynamic staff table with filters
- add Staff page and navigation link

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68638bde375c832fbe50affa150f06f3