### PR TITLE
Add dropdowns and role icons in staff panel

### DIFF
--- a/frontend/src/components/AddStaffModal.jsx
+++ b/frontend/src/components/AddStaffModal.jsx
@@ -2,7 +2,11 @@ import { useState } from 'react'
 import { addStaff } from '../supabase/staff'
 
 export default function AddStaffModal({ isOpen, onClose, onAdded }) {
-  const [form, setForm] = useState({ name: '', role: '', shift: '', status: '' })
+  const [form, setForm] = useState({ name: '', role: 'Chef', shift: 'Morning', status: 'Active' })
+
+  const roles = ['Chef', 'Cashier', 'Server']
+  const shifts = ['Morning', 'Evening']
+  const statuses = ['Active', 'On Leave', 'Terminated']
 
   if (!isOpen) return null
 
@@ -10,11 +14,16 @@ export default function AddStaffModal({ isOpen, onClose, onAdded }) {
     setForm({ ...form, [e.target.name]: e.target.value })
   }
 
+  function handleCancel() {
+    setForm({ name: '', role: 'Chef', shift: 'Morning', status: 'Active' })
+    onClose()
+  }
+
   async function handleSubmit(e) {
     e.preventDefault()
     await addStaff(form)
     onAdded()
-    setForm({ name: '', role: '', shift: '', status: '' })
+    setForm({ name: '', role: 'Chef', shift: 'Morning', status: 'Active' })
     onClose()
   }
 
@@ -30,30 +39,39 @@ export default function AddStaffModal({ isOpen, onClose, onAdded }) {
             value={form.name}
             onChange={handleChange}
           />
-          <input
+          <select
             className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
-            placeholder="Role"
             name="role"
             value={form.role}
             onChange={handleChange}
-          />
-          <input
+          >
+            {roles.map(r => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
+          <select
             className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
-            placeholder="Shift"
             name="shift"
             value={form.shift}
             onChange={handleChange}
-          />
-          <input
+          >
+            {shifts.map(s => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+          <select
             className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
-            placeholder="Status"
             name="status"
             value={form.status}
             onChange={handleChange}
-          />
+          >
+            {statuses.map(s => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
           <div className="space-x-2">
             <button type="submit" className="border border-[#800000] px-2 py-1">Save</button>
-            <button type="button" className="border border-[#800000] px-2 py-1" onClick={onClose}>
+            <button type="button" className="border border-[#800000] px-2 py-1" onClick={handleCancel}>
               Cancel
             </button>
           </div>

--- a/frontend/src/components/EditStaffModal.jsx
+++ b/frontend/src/components/EditStaffModal.jsx
@@ -2,7 +2,11 @@ import { useState, useEffect } from 'react'
 import { updateStaff } from '../supabase/staff'
 
 export default function EditStaffModal({ isOpen, staff, onClose, onUpdated }) {
-  const [form, setForm] = useState({ name: '', role: '', shift: '', status: '' })
+  const [form, setForm] = useState({ name: '', role: 'Chef', shift: 'Morning', status: 'Active' })
+
+  const roles = ['Chef', 'Cashier', 'Server']
+  const shifts = ['Morning', 'Evening']
+  const statuses = ['Active', 'On Leave', 'Terminated']
 
   useEffect(() => {
     if (staff) {
@@ -19,6 +23,10 @@ export default function EditStaffModal({ isOpen, staff, onClose, onUpdated }) {
 
   function handleChange(e) {
     setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  function handleCancel() {
+    onClose()
   }
 
   async function handleSubmit(e) {
@@ -40,30 +48,39 @@ export default function EditStaffModal({ isOpen, staff, onClose, onUpdated }) {
             value={form.name}
             onChange={handleChange}
           />
-          <input
+          <select
             className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
-            placeholder="Role"
             name="role"
             value={form.role}
             onChange={handleChange}
-          />
-          <input
+          >
+            {roles.map(r => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
+          <select
             className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
-            placeholder="Shift"
             name="shift"
             value={form.shift}
             onChange={handleChange}
-          />
-          <input
+          >
+            {shifts.map(s => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+          <select
             className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
-            placeholder="Status"
             name="status"
             value={form.status}
             onChange={handleChange}
-          />
+          >
+            {statuses.map(s => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
           <div className="space-x-2">
             <button type="submit" className="border border-[#800000] px-2 py-1">Save</button>
-            <button type="button" className="border border-[#800000] px-2 py-1" onClick={onClose}>Cancel</button>
+            <button type="button" className="border border-[#800000] px-2 py-1" onClick={handleCancel}>Cancel</button>
           </div>
         </form>
       </div>

--- a/frontend/src/components/StaffTable.jsx
+++ b/frontend/src/components/StaffTable.jsx
@@ -11,6 +11,8 @@ export default function StaffTable() {
   const [showAdd, setShowAdd] = useState(false)
   const [editItem, setEditItem] = useState(null)
 
+  const roleIcons = { Chef: '🍳', Cashier: '💰', Server: '🍽️' }
+
   useEffect(() => {
     fetchStaff()
   }, [filters])
@@ -85,7 +87,10 @@ export default function StaffTable() {
           {staff.map(s => (
             <tr key={s.id} className="border-b border-[#800000]">
               <td className="p-2">{s.name}</td>
-              <td className="p-2">{s.role}</td>
+              <td className="p-2 flex items-center space-x-1">
+                <span>{roleIcons[s.role] || '👤'}</span>
+                <span>{s.role}</span>
+              </td>
               <td className="p-2">{s.shift}</td>
               <td className="p-2">{s.status}</td>
               <td className="p-2">{new Date(s.created_at).toLocaleString()}</td>


### PR DESCRIPTION
## Summary
- update AddStaffModal with dropdown selectors for role, shift and status
- update EditStaffModal similarly for editing staff
- display emoji role icons in StaffTable

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686390b78038832f8337ee127e6299e9