### PR TITLE
Add low stock inventory alerts

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,11 +4,8 @@ import Reports from './pages/Reports'
 import Alerts from './pages/Alerts'
 import KingDashboard from './pages/KingDashboard'
 import DailyTasks from './pages/DailyTasks'
- codex/create-inventory-system-page
 import InventoryPage from './pages/InventoryPage'
-=======
 import StaffPage from './pages/StaffPage'
- main
 import Sidebar from './components/Sidebar'
 import Header from './components/Header'
 import { useRole } from './RoleContext'
@@ -24,18 +21,12 @@ function App() {
     content = <Reports onBack={() => setPage('home')} />
   } else if (page === 'inventory') {
     content = <InventoryPage />
- codex/build-smart-alerts-system-in-chefmind
   } else if (page === 'alerts') {
     content = <Alerts />
-=======
   } else if (page === 'tasks') {
     content = <DailyTasks />
- codex/create-staffpage-with-crud-and-filters
   } else if (page === 'staff') {
     content = <StaffPage />
-=======
- main
- main
   } else {
     content = <Home onViewReports={() => setPage('reports')} />
   }

--- a/frontend/src/components/AddInventoryModal.jsx
+++ b/frontend/src/components/AddInventoryModal.jsx
@@ -1,15 +1,25 @@
 import { useState } from 'react'
 
 export default function AddInventoryModal({ onClose, onAdd }) {
-  const [form, setForm] = useState({ item_name: '', quantity: 0, unit: '' })
+  const [form, setForm] = useState({
+    item_name: '',
+    quantity: 0,
+    unit: '',
+    low_stock_alert: false
+  })
 
   function handleChange(e) {
-    setForm({ ...form, [e.target.name]: e.target.value })
+    const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value
+    setForm({ ...form, [e.target.name]: value })
   }
 
   function handleSubmit(e) {
     e.preventDefault()
-    onAdd({ ...form, quantity: Number(form.quantity) })
+    onAdd({
+      ...form,
+      quantity: Number(form.quantity),
+      low_stock_alert: Boolean(form.low_stock_alert)
+    })
   }
 
   return (
@@ -38,6 +48,15 @@ export default function AddInventoryModal({ onClose, onAdd }) {
           value={form.unit}
           onChange={handleChange}
         />
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            name="low_stock_alert"
+            checked={form.low_stock_alert}
+            onChange={handleChange}
+          />
+          <span>Enable Low Stock Alert</span>
+        </label>
         <div className="space-x-2 text-right">
           <button type="submit" className="border border-[#800000] px-2 py-1">Save</button>
           <button type="button" className="border border-[#800000] px-2 py-1" onClick={onClose}>Cancel</button>

--- a/frontend/src/components/EditInventoryModal.jsx
+++ b/frontend/src/components/EditInventoryModal.jsx
@@ -1,15 +1,24 @@
 import { useState } from 'react'
 
 export default function EditInventoryModal({ item, onClose, onSave }) {
-  const [form, setForm] = useState({ quantity: item.quantity, unit: item.unit })
+  const [form, setForm] = useState({
+    quantity: item.quantity,
+    unit: item.unit,
+    low_stock_alert: item.low_stock_alert
+  })
 
   function handleChange(e) {
-    setForm({ ...form, [e.target.name]: e.target.value })
+    const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value
+    setForm({ ...form, [e.target.name]: value })
   }
 
   function handleSubmit(e) {
     e.preventDefault()
-    onSave({ ...form, quantity: Number(form.quantity) })
+    onSave({
+      ...form,
+      quantity: Number(form.quantity),
+      low_stock_alert: Boolean(form.low_stock_alert)
+    })
   }
 
   return (
@@ -32,6 +41,15 @@ export default function EditInventoryModal({ item, onClose, onSave }) {
           value={form.unit}
           onChange={handleChange}
         />
+        <label className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            name="low_stock_alert"
+            checked={form.low_stock_alert}
+            onChange={handleChange}
+          />
+          <span>Enable Low Stock Alert</span>
+        </label>
         <div className="space-x-2 text-right">
           <button type="submit" className="border border-[#800000] px-2 py-1">Save</button>
           <button type="button" className="border border-[#800000] px-2 py-1" onClick={onClose}>Cancel</button>

--- a/frontend/src/components/InventoryTable.jsx
+++ b/frontend/src/components/InventoryTable.jsx
@@ -1,4 +1,11 @@
-export default function InventoryTable({ items, onEdit, onDelete, canDelete }) {
+export default function InventoryTable({
+  items,
+  onEdit,
+  onDelete,
+  canDelete,
+  lowThreshold = 5
+}) {
+
   return (
     <table className="w-full text-left border border-[#800000]">
       <thead>
@@ -7,18 +14,23 @@ export default function InventoryTable({ items, onEdit, onDelete, canDelete }) {
           <th className="p-2">Qty</th>
           <th className="p-2">Unit</th>
           <th className="p-2">Alert</th>
+          <th className="p-2">Created</th>
           <th className="p-2">Actions</th>
         </tr>
       </thead>
       <tbody>
         {items.map(item => (
           <tr key={item.id} className="border-b border-[#800000]">
-            <td className="p-2">{item.item_name}</td>
+            <td className="p-2">
+              {item.item_name}
+              {item.low_stock_alert && item.quantity < lowThreshold && (
+                <span className="ml-1 text-red-500">&#x26A0;</span>
+              )}
+            </td>
             <td className="p-2">{item.quantity}</td>
             <td className="p-2">{item.unit}</td>
-            <td className="p-2">
-              {item.low_stock_alert ? <span className="text-red-500">&#x1F534;</span> : ''}
-            </td>
+            <td className="p-2">{item.low_stock_alert ? '✅' : '❌'}</td>
+            <td className="p-2">{new Date(item.created_at).toLocaleString()}</td>
             <td className="p-2 space-x-1">
               <button
                 className="border border-[#800000] px-2"

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -11,26 +11,17 @@ export default function Sidebar({ onNavigate }) {
       <button className="block" onClick={() => onNavigate('reports')}>
         Reports
       </button>
- codex/create-inventory-system-page
       <button className="block" onClick={() => onNavigate('inventory')}>
         Inventory
       </button>
-codex/build-smart-alerts-system-in-chefmind
-=======
- codex/create-staffpage-with-crud-and-filters
       <button className="block" onClick={() => onNavigate('staff')}>
         Staff
       </button>
-=======
- codex/build-smart-alerts-system-in-chefmind
- main
       <button className="block" onClick={() => onNavigate('alerts')}>
         Alerts
-=======
- main
+      </button>
       <button className="block" onClick={() => onNavigate('tasks')}>
         Tasks
- main
       </button>
       {role === 'King' && (
         <button className="block" onClick={() => onNavigate('king')}>Admin Panel</button>

--- a/frontend/src/pages/InventoryPage.jsx
+++ b/frontend/src/pages/InventoryPage.jsx
@@ -51,6 +51,7 @@ export default function InventoryPage() {
         onEdit={item => setEditItem(item)}
         onDelete={handleDelete}
         canDelete={role === 'King'}
+        lowThreshold={5}
       />
       <button className="border border-[#800000] px-2 py-1" onClick={() => setShowAdd(true)}>
         Add Item


### PR DESCRIPTION
## Summary
- clean leftover codex markers
- show created date and warnings in inventory table
- allow enabling low stock alerts when adding/editing items
- expose low stock threshold option

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686391034e58832fb6f981fc018621e8