### PR TITLE
Add daily shift report CRUD

### DIFF
--- a/frontend/src/supabase/dailyReports.js
+++ b/frontend/src/supabase/dailyReports.js
@@ -1,0 +1,34 @@
+import { supabase } from '../supabase'
+
+export async function getReports() {
+  const { data, error } = await supabase
+    .from('daily_reports')
+    .select('id, date, shift, notes, issues, created_at, staff_id, staff(name)')
+    .order('date', { ascending: false })
+  if (error) throw error
+  return data || []
+}
+
+export async function addReport(report) {
+  const { data: existing, error: existError } = await supabase
+    .from('daily_reports')
+    .select('id')
+    .eq('date', report.date)
+    .eq('shift', report.shift)
+    .maybeSingle()
+  if (existError) throw existError
+  if (existing) throw new Error('Report already exists for this shift and date')
+
+  const { error } = await supabase.from('daily_reports').insert(report)
+  if (error) throw error
+}
+
+export async function updateReport(id, data) {
+  const { error } = await supabase.from('daily_reports').update(data).eq('id', id)
+  if (error) throw error
+}
+
+export async function deleteReport(id) {
+  const { error } = await supabase.from('daily_reports').delete().eq('id', id)
+  if (error) throw error
+}


### PR DESCRIPTION
## Summary
- add Supabase helpers for daily reports
- upgrade Daily Reports page with create/edit/delete functionality
- show creation date and shift options Morning/Evening/Overnight
- prevent duplicate shift reports for same day

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686391cabbe8832fb92300e85d59a3bf