### PR TITLE
Add shift scheduler page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import KingDashboard from './pages/KingDashboard'
 import DailyTasks from './pages/DailyTasks'
 import InventoryPage from './pages/InventoryPage'
 import StaffPage from './pages/StaffPage'
+import ShiftScheduler from './pages/ShiftScheduler'
 import Sidebar from './components/Sidebar'
 import Header from './components/Header'
 import { useRole } from './RoleContext'
@@ -27,6 +28,8 @@ function App() {
     content = <DailyTasks />
   } else if (page === 'staff') {
     content = <StaffPage />
+  } else if (page === 'schedule') {
+    content = <ShiftScheduler />
   } else {
     content = <Home onViewReports={() => setPage('reports')} />
   }

--- a/frontend/src/components/ShiftModal.jsx
+++ b/frontend/src/components/ShiftModal.jsx
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react'
+
+const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+const shifts = ['Morning', 'Evening', 'Overnight']
+
+export default function ShiftModal({ staff = [], onClose, onSave, initial }) {
+  const [form, setForm] = useState({ staff_id: '', day: days[0], shift: shifts[0] })
+
+  useEffect(() => {
+    if (initial) {
+      setForm({
+        staff_id: initial.staff_id || '',
+        day: initial.day || days[0],
+        shift: initial.shift || shifts[0]
+      })
+    }
+  }, [initial])
+
+  function handleChange(e) {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  function handleSubmit(e) {
+    e.preventDefault()
+    onSave(form)
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-gray-800 p-4 rounded space-y-2 w-72">
+        <h3 className="text-lg text-[#FFD700]">{initial ? 'Edit Shift' : 'Add Shift'}</h3>
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <select
+            className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            name="staff_id"
+            value={form.staff_id}
+            onChange={handleChange}
+          >
+            <option value="">Select Staff</option>
+            {staff.map(s => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+          <select
+            className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            name="day"
+            value={form.day}
+            onChange={handleChange}
+          >
+            {days.map(d => (
+              <option key={d} value={d}>{d}</option>
+            ))}
+          </select>
+          <select
+            className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            name="shift"
+            value={form.shift}
+            onChange={handleChange}
+          >
+            {shifts.map(s => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+          <div className="space-x-2">
+            <button type="submit" className="border border-[#800000] px-2 py-1">Save</button>
+            <button type="button" className="border border-[#800000] px-2 py-1" onClick={onClose}>Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -17,6 +17,9 @@ export default function Sidebar({ onNavigate }) {
       <button className="block" onClick={() => onNavigate('staff')}>
         Staff
       </button>
+      <button className="block" onClick={() => onNavigate('schedule')}>
+        Schedule
+      </button>
       <button className="block" onClick={() => onNavigate('alerts')}>
         Alerts
       </button>

--- a/frontend/src/pages/ShiftScheduler.jsx
+++ b/frontend/src/pages/ShiftScheduler.jsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react'
+import { getSchedule, addSchedule, updateSchedule, deleteSchedule } from '../supabase/shiftsSchedule'
+import { supabase } from '../supabase'
+import ShiftModal from '../components/ShiftModal'
+
+const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+const shifts = ['Morning', 'Evening', 'Overnight']
+
+export default function ShiftScheduler() {
+  const [schedule, setSchedule] = useState([])
+  const [staff, setStaff] = useState([])
+  const [showAdd, setShowAdd] = useState(false)
+  const [editItem, setEditItem] = useState(null)
+
+  useEffect(() => {
+    fetchSchedule()
+    fetchStaff()
+  }, [])
+
+  async function fetchSchedule() {
+    try {
+      const data = await getSchedule()
+      setSchedule(data)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  async function fetchStaff() {
+    const { data } = await supabase.from('staff').select('id, name')
+    setStaff(data || [])
+  }
+
+  async function handleAdd(data) {
+    await addSchedule(data)
+    setShowAdd(false)
+    fetchSchedule()
+  }
+
+  async function handleEdit(id, data) {
+    await updateSchedule(id, data)
+    setEditItem(null)
+    fetchSchedule()
+  }
+
+  async function handleDelete(id) {
+    if (!confirm('Delete this shift?')) return
+    await deleteSchedule(id)
+    fetchSchedule()
+  }
+
+  function cellContent(day, shift) {
+    return schedule
+      .filter(s => s.day === day && s.shift === shift)
+      .map(item => (
+        <div key={item.id} className="flex items-center justify-between">
+          <span>{item.staff?.name}</span>
+          <div className="space-x-1">
+            <button className="border border-[#800000] px-1" onClick={() => setEditItem(item)}>Edit</button>
+            <button className="border border-[#800000] px-1" onClick={() => handleDelete(item.id)}>X</button>
+          </div>
+        </div>
+      ))
+  }
+
+  return (
+    <div className="space-y-4 text-[#FFD700]">
+      <h2 className="text-xl font-bold">Shift Scheduler</h2>
+      <table className="w-full text-left border border-[#800000]">
+        <thead>
+          <tr className="border-b border-[#800000]">
+            <th className="p-2">Shift</th>
+            {days.map(d => (
+              <th key={d} className="p-2">{d}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {shifts.map(sh => (
+            <tr key={sh} className="border-b border-[#800000]">
+              <td className="p-2 font-semibold">{sh}</td>
+              {days.map(day => (
+                <td key={day} className="p-2 align-top space-y-1">
+                  {cellContent(day, sh)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button className="border border-[#800000] px-2 py-1" onClick={() => setShowAdd(true)}>Add Shift</button>
+      {showAdd && (
+        <ShiftModal staff={staff} onClose={() => setShowAdd(false)} onSave={handleAdd} />
+      )}
+      {editItem && (
+        <ShiftModal
+          staff={staff}
+          initial={editItem}
+          onClose={() => setEditItem(null)}
+          onSave={data => handleEdit(editItem.id, data)}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/supabase/shiftsSchedule.js
+++ b/frontend/src/supabase/shiftsSchedule.js
@@ -1,0 +1,27 @@
+import { supabase } from '../supabase'
+
+export async function getSchedule() {
+  const { data, error } = await supabase
+    .from('shifts_schedule')
+    .select('id, day, shift, staff_id, staff(name)')
+  if (error) throw error
+  return data || []
+}
+
+export async function addSchedule(item) {
+  const { error } = await supabase.from('shifts_schedule').insert(item)
+  if (error) throw error
+}
+
+export async function updateSchedule(id, data) {
+  const { error } = await supabase
+    .from('shifts_schedule')
+    .update(data)
+    .eq('id', id)
+  if (error) throw error
+}
+
+export async function deleteSchedule(id) {
+  const { error } = await supabase.from('shifts_schedule').delete().eq('id', id)
+  if (error) throw error
+}

--- a/frontend/supabase-schema.sql
+++ b/frontend/supabase-schema.sql
@@ -31,3 +31,11 @@ create table daily_tasks (
  main
   created_at timestamp default now()
 );
+
+create table shifts_schedule (
+  id uuid default uuid_generate_v4() primary key,
+  staff_id uuid references staff(id),
+  day text,
+  shift text,
+  created_at timestamp default now()
+);


### PR DESCRIPTION
## Summary
- add ShiftScheduler page with grid layout for weekly shifts
- allow adding/editing/deleting schedule entries via ShiftModal
- connect to new `shifts_schedule` table
- expose schedule in sidebar and route in `App.jsx`
- update Supabase schema

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864eb481004832f834bf24333487c26