### PR TITLE
Add orders tables to Supabase schema

### DIFF
--- a/frontend/supabase-schema.sql
+++ b/frontend/supabase-schema.sql
@@ -39,3 +39,22 @@ create table shifts_schedule (
   shift text,
   created_at timestamp default now()
 );
+
+-- codex/create-orders-tables
+create table orders (
+  id uuid default uuid_generate_v4() primary key,
+  order_number serial,
+  staff_id uuid references staff(id),
+  shift text,
+  status text,
+  notes text,
+  created_at timestamp default now()
+);
+
+create table order_items (
+  id uuid default uuid_generate_v4() primary key,
+  order_id uuid references orders(id),
+  menu_item_id uuid references menu_items(id),
+  quantity integer default 1,
+  special_request text
+);


### PR DESCRIPTION
## Summary
- define `orders` and `order_items` tables in the Supabase schema

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_686c4742057c832fbd6ac1b314b2b1b5