### PR TITLE
Add Upsell Center page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import InventoryPage from './pages/InventoryPage'
 import StaffPage from './pages/StaffPage'
 import ShiftScheduler from './pages/ShiftScheduler'
 import Shifts from './pages/Shifts'
+import UpsellCenter from './pages/UpsellCenter'
 import Sidebar from './components/Sidebar'
 import Header from './components/Header'
 import { useRole } from './RoleContext'
@@ -33,6 +34,8 @@ function App() {
     content = <Shifts />
   } else if (page === 'schedule') {
     content = <ShiftScheduler />
+  } else if (page === 'upsell') {
+    content = <UpsellCenter />
   } else {
     content = <Home onViewReports={() => setPage('dailyReports')} />
   }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -29,6 +29,9 @@ export default function Sidebar({ onNavigate }) {
       <button className="block" onClick={() => onNavigate('tasks')}>
         Tasks
       </button>
+      <button className="block" onClick={() => onNavigate('upsell')}>
+        Upsell Center
+      </button>
       {role === 'King' && (
         <button className="block" onClick={() => onNavigate('king')}>Admin Panel</button>
       )}

--- a/frontend/src/pages/UpsellCenter.jsx
+++ b/frontend/src/pages/UpsellCenter.jsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react'
+import { getUpsellItems, addOrderItem, getTopSellers, getLatestNote } from '../supabase/upsell'
+
+export default function UpsellCenter() {
+  const [items, setItems] = useState([])
+  const [top, setTop] = useState([])
+  const [note, setNote] = useState(null)
+
+  useEffect(() => {
+    fetchItems()
+    fetchTop()
+    fetchNote()
+  }, [])
+
+  async function fetchItems() {
+    try {
+      const data = await getUpsellItems()
+      setItems(data)
+    } catch (err) {
+      console.error('Failed to fetch upsell items', err)
+    }
+  }
+
+  async function fetchTop() {
+    try {
+      const data = await getTopSellers()
+      setTop(data)
+    } catch (err) {
+      console.error('Failed to fetch top sellers', err)
+    }
+  }
+
+  async function fetchNote() {
+    try {
+      const data = await getLatestNote()
+      setNote(data)
+    } catch (err) {
+      console.error('Failed to fetch note', err)
+    }
+  }
+
+  async function handleAdd(item) {
+    try {
+      await addOrderItem(item.id)
+    } catch (err) {
+      console.error('Failed to add to order', err)
+    }
+  }
+
+  return (
+    <div className='space-y-6 text-[#FFD700]'>
+      <h2 className='text-xl font-bold'>Upsell Center</h2>
+
+      <section>
+        <h3 className='text-lg font-semibold mb-2'>Today\'s Offers</h3>
+        <div className='grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3'>
+          {items.map(item => (
+            <div key={item.id} className='border border-[#800000] p-2'>
+              {item.image_url && (
+                <img src={item.image_url} alt={item.title} className='w-full h-32 object-cover mb-2' />
+              )}
+              <div className='font-bold'>{item.title} - ${item.price}</div>
+              <p className='text-sm mb-2'>{item.description}</p>
+              <button className='border border-[#800000] px-2 py-1' onClick={() => handleAdd(item)}>
+                Add to Order
+              </button>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h3 className='text-lg font-semibold mb-2'>Top Sellers</h3>
+        <ul className='list-disc pl-5 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2'>
+          {top.map(t => (
+            <li key={t.item} className='border border-[#800000] p-2 flex justify-between'>
+              <span>{t.item}</span>
+              <span>{t.count}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h3 className='text-lg font-semibold mb-2'>Admin Picks</h3>
+        {note && <div className='border border-[#800000] p-3'>{note.note}</div>}
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/supabase/upsell.js
+++ b/frontend/src/supabase/upsell.js
@@ -1,0 +1,38 @@
+import { supabase } from '../supabase'
+
+export async function getUpsellItems() {
+  const { data, error } = await supabase
+    .from('upsell_items')
+    .select('id, title, description, price, image_url')
+    .eq('available', true)
+  if (error) throw error
+  return data || []
+}
+
+export async function addOrderItem(itemId) {
+  const { error } = await supabase.from('orders').insert({ item_id: itemId })
+  if (error) throw error
+}
+
+export async function getTopSellers() {
+  const { data, error } = await supabase.from('orders').select('item_name')
+  if (error) throw error
+  const counts = {}
+  for (const row of data || []) {
+    counts[row.item_name] = (counts[row.item_name] || 0) + 1
+  }
+  return Object.entries(counts)
+    .map(([item, count]) => ({ item, count }))
+    .sort((a, b) => b.count - a.count)
+}
+
+export async function getLatestNote() {
+  const { data, error } = await supabase
+    .from('daily_notes')
+    .select('note')
+    .order('date', { ascending: false })
+    .limit(1)
+    .single()
+  if (error) throw error
+  return data
+}

--- a/frontend/supabase-schema.sql
+++ b/frontend/supabase-schema.sql
@@ -39,3 +39,20 @@ create table shifts_schedule (
   shift text,
   created_at timestamp default now()
 );
+
+create table upsell_items (
+  id uuid default uuid_generate_v4() primary key,
+  title text,
+  description text,
+  price float,
+  image_url text,
+  available boolean default true,
+  created_at timestamp default now()
+);
+
+create table daily_notes (
+  id uuid default uuid_generate_v4() primary key,
+  note text,
+  date date,
+  created_at timestamp default now()
+);


### PR DESCRIPTION
## Summary
- add UpsellCenter page for management upsell features
- expose upsell helper functions in Supabase helper
- route Upsell Center via App and Sidebar
- extend Supabase schema with upsell_items and daily_notes tables

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4754e610832facac576f7c238a98