### PR TITLE
Add Offers page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import InventoryPage from './pages/InventoryPage'
 import StaffPage from './pages/StaffPage'
 import ShiftScheduler from './pages/ShiftScheduler'
 import Shifts from './pages/Shifts'
+import Offers from './pages/Offers'
 import Sidebar from './components/Sidebar'
 import Header from './components/Header'
 import { useRole } from './RoleContext'
@@ -33,6 +34,8 @@ function App() {
     content = <Shifts />
   } else if (page === 'schedule') {
     content = <ShiftScheduler />
+  } else if (page === 'offers') {
+    content = <Offers />
   } else {
     content = <Home onViewReports={() => setPage('dailyReports')} />
   }

--- a/frontend/src/components/AddOfferModal.jsx
+++ b/frontend/src/components/AddOfferModal.jsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { addOffer } from '../supabase/offers'
+
+export default function AddOfferModal({ onClose, onAdd }) {
+  const [form, setForm] = useState({
+    title: '',
+    description: '',
+    discount_percent: 0,
+    valid_from: '',
+    valid_to: '',
+    is_active: true
+  })
+
+  function handleChange(e) {
+    const { name, type, value, checked } = e.target
+    setForm({ ...form, [name]: type === 'checkbox' ? checked : value })
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    await addOffer({
+      ...form,
+      discount_percent: Number(form.discount_percent)
+    })
+    onAdd()
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50">
+      <form onSubmit={handleSubmit} className="bg-gray-900 p-4 space-y-2 border-2 border-[#800000] text-[#FFD700]">
+        <h2 className="text-lg font-bold">Add Offer</h2>
+        <input
+          name="title"
+          className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+          placeholder="Title"
+          value={form.title}
+          onChange={handleChange}
+          required
+        />
+        <textarea
+          name="description"
+          className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+          placeholder="Description"
+          value={form.description}
+          onChange={handleChange}
+        />
+        <input
+          name="discount_percent"
+          type="number"
+          className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+          placeholder="Discount %"
+          value={form.discount_percent}
+          onChange={handleChange}
+        />
+        <input
+          type="date"
+          name="valid_from"
+          className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+          value={form.valid_from}
+          onChange={handleChange}
+        />
+        <input
+          type="date"
+          name="valid_to"
+          className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+          value={form.valid_to}
+          onChange={handleChange}
+        />
+        <label className="flex items-center space-x-2">
+          <input type="checkbox" name="is_active" checked={form.is_active} onChange={handleChange} />
+          <span>Active</span>
+        </label>
+        <div className="space-x-2">
+          <button type="submit" className="border border-[#800000] px-2 py-1">Save</button>
+          <button type="button" className="border border-[#800000] px-2 py-1" onClick={onClose}>Cancel</button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -23,6 +23,9 @@ export default function Sidebar({ onNavigate }) {
       <button className="block" onClick={() => onNavigate('schedule')}>
         Schedule
       </button>
+      <button className="block" onClick={() => onNavigate('offers')}>
+        Offers
+      </button>
       <button className="block" onClick={() => onNavigate('alerts')}>
         Alerts
       </button>

--- a/frontend/src/pages/Offers.jsx
+++ b/frontend/src/pages/Offers.jsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react'
+import { getOffers, updateOffer } from '../supabase/offers'
+import AddOfferModal from '../components/AddOfferModal'
+
+export default function Offers() {
+  const [offers, setOffers] = useState([])
+  const [showAdd, setShowAdd] = useState(false)
+  const [filter, setFilter] = useState('all')
+
+  async function fetchData() {
+    try {
+      const filters = {}
+      if (filter === 'active') filters.is_active = true
+      if (filter === 'inactive') filters.is_active = false
+      const data = await getOffers(filters)
+      setOffers(data)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  useEffect(() => {
+    fetchData()
+  }, [filter])
+
+  async function toggleActive(offer) {
+    await updateOffer(offer.id, { is_active: !offer.is_active })
+    fetchData()
+  }
+
+  return (
+    <div className="space-y-4 text-[#FFD700]">
+      <h2 className="text-xl font-bold">Offers</h2>
+      <div className="space-x-2">
+        <select
+          className="border border-[#800000] bg-black text-[#FFD700] p-1"
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+        >
+          <option value="all">All</option>
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
+        </select>
+        <button className="border border-[#800000] px-2 py-1" onClick={() => setShowAdd(true)}>
+          Add New Offer
+        </button>
+      </div>
+      <table className="w-full text-left border border-[#800000]">
+        <thead>
+          <tr className="border-b border-[#800000]">
+            <th className="p-2">Title</th>
+            <th className="p-2">Discount %</th>
+            <th className="p-2">Valid</th>
+            <th className="p-2">Status</th>
+            <th className="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {offers.map(o => {
+            const now = new Date()
+            const validTo = o.valid_to ? new Date(o.valid_to) : null
+            const active = o.is_active && (!validTo || validTo >= now)
+            return (
+              <tr key={o.id} className="border-b border-[#800000]">
+                <td className="p-2">{o.title}</td>
+                <td className="p-2">{o.discount_percent || 0}%</td>
+                <td className="p-2">
+                  {o.valid_from || '?'} → {o.valid_to || '?'}
+                </td>
+                <td className="p-2">{active ? 'Active' : 'Expired'}</td>
+                <td className="p-2">
+                  <button className="border border-[#800000] px-1" onClick={() => toggleActive(o)}>
+                    {o.is_active ? 'Disable' : 'Enable'}
+                  </button>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      {showAdd && <AddOfferModal onClose={() => { setShowAdd(false) }} onAdd={() => { setShowAdd(false); fetchData() }} />}
+    </div>
+  )
+}

--- a/frontend/src/supabase/offers.js
+++ b/frontend/src/supabase/offers.js
@@ -1,0 +1,22 @@
+import { supabase } from '../supabase'
+
+export async function getOffers(filters = {}) {
+  let query = supabase.from('offers').select('*').order('created_at', { ascending: false })
+  if (filters.is_active !== undefined) query = query.eq('is_active', filters.is_active)
+  if (filters.date) {
+    query = query.lte('valid_from', filters.date).gte('valid_to', filters.date)
+  }
+  const { data, error } = await query
+  if (error) throw error
+  return data || []
+}
+
+export async function addOffer(data) {
+  const { error } = await supabase.from('offers').insert(data)
+  if (error) throw error
+}
+
+export async function updateOffer(id, data) {
+  const { error } = await supabase.from('offers').update(data).eq('id', id)
+  if (error) throw error
+}

--- a/frontend/supabase-schema.sql
+++ b/frontend/supabase-schema.sql
@@ -17,18 +17,18 @@ create table daily_reports (
   created_at timestamp default now()
 );
 
- codex/build-smart-alerts-system-in-chefmind
 create table dismissed_alerts (
   id uuid default uuid_generate_v4() primary key,
   message text,
-=======
+  created_at timestamp default now()
+);
+
 create table daily_tasks (
   id uuid default uuid_generate_v4() primary key,
   task text,
   shift text,
   status text default 'pending',
   staff_id uuid references staff(id),
- main
   created_at timestamp default now()
 );
 
@@ -37,5 +37,16 @@ create table shifts_schedule (
   staff_id uuid references staff(id),
   day text,
   shift text,
+  created_at timestamp default now()
+);
+
+create table offers (
+  id uuid default uuid_generate_v4() primary key,
+  title text not null,
+  description text,
+  discount_percent integer,
+  valid_from date,
+  valid_to date,
+  is_active boolean default true,
   created_at timestamp default now()
 );


### PR DESCRIPTION
## Summary
- fix Supabase schema merge leftovers and add new `offers` table
- add supabase API for offers
- add modal to add new offer
- create Offers page with filtering and toggle active state
- hook page into app sidebar and routing

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c475e74e8832fb0e8ef1db2a74a2b