### PR TITLE
Add inventory management features

### DIFF
--- a/frontend/src/components/AddInventoryModal.jsx
+++ b/frontend/src/components/AddInventoryModal.jsx
@@ -4,12 +4,11 @@ export default function AddInventoryModal({ onClose, onAdd }) {
   const [form, setForm] = useState({
     item_name: '',
     quantity: 0,
-    unit: '',
-    low_stock_alert: false
+    unit: ''
   })
 
   function handleChange(e) {
-    const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value
+    const value = e.target.value
     setForm({ ...form, [e.target.name]: value })
   }
 
@@ -18,7 +17,7 @@ export default function AddInventoryModal({ onClose, onAdd }) {
     onAdd({
       ...form,
       quantity: Number(form.quantity),
-      low_stock_alert: Boolean(form.low_stock_alert)
+      low_stock_alert: Number(form.quantity) < 5
     })
   }
 
@@ -48,15 +47,6 @@ export default function AddInventoryModal({ onClose, onAdd }) {
           value={form.unit}
           onChange={handleChange}
         />
-        <label className="flex items-center space-x-2">
-          <input
-            type="checkbox"
-            name="low_stock_alert"
-            checked={form.low_stock_alert}
-            onChange={handleChange}
-          />
-          <span>Enable Low Stock Alert</span>
-        </label>
         <div className="space-x-2 text-right">
           <button type="submit" className="border border-[#800000] px-2 py-1">Save</button>
           <button type="button" className="border border-[#800000] px-2 py-1" onClick={onClose}>Cancel</button>

--- a/frontend/src/components/EditInventoryModal.jsx
+++ b/frontend/src/components/EditInventoryModal.jsx
@@ -3,12 +3,11 @@ import { useState } from 'react'
 export default function EditInventoryModal({ item, onClose, onSave }) {
   const [form, setForm] = useState({
     quantity: item.quantity,
-    unit: item.unit,
-    low_stock_alert: item.low_stock_alert
+    unit: item.unit
   })
 
   function handleChange(e) {
-    const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value
+    const value = e.target.value
     setForm({ ...form, [e.target.name]: value })
   }
 
@@ -17,7 +16,7 @@ export default function EditInventoryModal({ item, onClose, onSave }) {
     onSave({
       ...form,
       quantity: Number(form.quantity),
-      low_stock_alert: Boolean(form.low_stock_alert)
+      low_stock_alert: Number(form.quantity) < 5
     })
   }
 
@@ -41,15 +40,6 @@ export default function EditInventoryModal({ item, onClose, onSave }) {
           value={form.unit}
           onChange={handleChange}
         />
-        <label className="flex items-center space-x-2">
-          <input
-            type="checkbox"
-            name="low_stock_alert"
-            checked={form.low_stock_alert}
-            onChange={handleChange}
-          />
-          <span>Enable Low Stock Alert</span>
-        </label>
         <div className="space-x-2 text-right">
           <button type="submit" className="border border-[#800000] px-2 py-1">Save</button>
           <button type="button" className="border border-[#800000] px-2 py-1" onClick={onClose}>Cancel</button>

--- a/frontend/src/components/InventoryTable.jsx
+++ b/frontend/src/components/InventoryTable.jsx
@@ -29,7 +29,7 @@ export default function InventoryTable({
             </td>
             <td className="p-2">{item.quantity}</td>
             <td className="p-2">{item.unit}</td>
-            <td className="p-2">{item.low_stock_alert ? '✅' : '❌'}</td>
+            <td className="p-2">{item.low_stock_alert ? 'Low' : 'OK'}</td>
             <td className="p-2">{new Date(item.created_at).toLocaleString()}</td>
             <td className="p-2 space-x-1">
               <button

--- a/frontend/src/pages/InventoryPage.jsx
+++ b/frontend/src/pages/InventoryPage.jsx
@@ -10,6 +10,7 @@ export default function InventoryPage() {
   const [items, setItems] = useState([])
   const [showAdd, setShowAdd] = useState(false)
   const [editItem, setEditItem] = useState(null)
+  const [showLowOnly, setShowLowOnly] = useState(false)
 
   async function fetchData() {
     try {
@@ -43,11 +44,22 @@ export default function InventoryPage() {
     }
   }
 
+  const displayed = showLowOnly ? items.filter(i => i.low_stock_alert) : items
+
   return (
     <div className="space-y-4 text-[#FFD700]">
       <h2 className="text-xl font-bold">Inventory</h2>
+      <label className="block">
+        <input
+          type="checkbox"
+          checked={showLowOnly}
+          onChange={e => setShowLowOnly(e.target.checked)}
+          className="mr-1"
+        />
+        Show Low Stock Only
+      </label>
       <InventoryTable
-        items={items}
+        items={displayed}
         onEdit={item => setEditItem(item)}
         onDelete={handleDelete}
         canDelete={role === 'King'}

--- a/frontend/src/supabase/inventory.js
+++ b/frontend/src/supabase/inventory.js
@@ -10,12 +10,20 @@ export async function getInventory() {
 }
 
 export async function addItem(item) {
-  const { error } = await supabase.from('inventory').insert(item)
+  const record = {
+    ...item,
+    low_stock_alert: item.quantity < 5
+  }
+  const { error } = await supabase.from('inventory').insert(record)
   if (error) throw error
 }
 
 export async function updateItem(id, data) {
-  const { error } = await supabase.from('inventory').update(data).eq('id', id)
+  const record = {
+    ...data,
+    low_stock_alert: data.quantity < 5
+  }
+  const { error } = await supabase.from('inventory').update(record).eq('id', id)
   if (error) throw error
 }
 

--- a/frontend/supabase-schema.sql
+++ b/frontend/supabase-schema.sql
@@ -17,18 +17,12 @@ create table daily_reports (
   created_at timestamp default now()
 );
 
- codex/build-smart-alerts-system-in-chefmind
-create table dismissed_alerts (
-  id uuid default uuid_generate_v4() primary key,
-  message text,
-=======
 create table daily_tasks (
   id uuid default uuid_generate_v4() primary key,
   task text,
   shift text,
   status text default 'pending',
   staff_id uuid references staff(id),
- main
   created_at timestamp default now()
 );
 
@@ -37,5 +31,14 @@ create table shifts_schedule (
   staff_id uuid references staff(id),
   day text,
   shift text,
+  created_at timestamp default now()
+);
+
+create table inventory (
+  id uuid default uuid_generate_v4() primary key,
+  item_name text not null,
+  quantity integer not null,
+  unit text,
+  low_stock_alert boolean default false,
   created_at timestamp default now()
 );


### PR DESCRIPTION
## Summary
- create a clean Supabase schema file including new `inventory` table
- simplify inventory modals and automatically set `low_stock_alert` when quantity is under 5
- display low stock status as `Low` or `OK`
- add filter checkbox on Inventory page
- enforce low stock logic in Supabase helpers

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c48575cc8832fa42ea8c987fb3d8c