### PR TITLE
Implement inventory management page and auto low-stock detection

### DIFF
--- a/frontend/src/components/AddInventoryModal.jsx
+++ b/frontend/src/components/AddInventoryModal.jsx
@@ -4,8 +4,7 @@ export default function AddInventoryModal({ onClose, onAdd }) {
   const [form, setForm] = useState({
     item_name: '',
     quantity: 0,
-    unit: '',
-    low_stock_alert: false
+    unit: ''
   })
 
   function handleChange(e) {
@@ -17,8 +16,7 @@ export default function AddInventoryModal({ onClose, onAdd }) {
     e.preventDefault()
     onAdd({
       ...form,
-      quantity: Number(form.quantity),
-      low_stock_alert: Boolean(form.low_stock_alert)
+      quantity: Number(form.quantity)
     })
   }
 
@@ -48,15 +46,6 @@ export default function AddInventoryModal({ onClose, onAdd }) {
           value={form.unit}
           onChange={handleChange}
         />
-        <label className="flex items-center space-x-2">
-          <input
-            type="checkbox"
-            name="low_stock_alert"
-            checked={form.low_stock_alert}
-            onChange={handleChange}
-          />
-          <span>Enable Low Stock Alert</span>
-        </label>
         <div className="space-x-2 text-right">
           <button type="submit" className="border border-[#800000] px-2 py-1">Save</button>
           <button type="button" className="border border-[#800000] px-2 py-1" onClick={onClose}>Cancel</button>

--- a/frontend/src/components/EditInventoryModal.jsx
+++ b/frontend/src/components/EditInventoryModal.jsx
@@ -3,8 +3,7 @@ import { useState } from 'react'
 export default function EditInventoryModal({ item, onClose, onSave }) {
   const [form, setForm] = useState({
     quantity: item.quantity,
-    unit: item.unit,
-    low_stock_alert: item.low_stock_alert
+    unit: item.unit
   })
 
   function handleChange(e) {
@@ -16,8 +15,7 @@ export default function EditInventoryModal({ item, onClose, onSave }) {
     e.preventDefault()
     onSave({
       ...form,
-      quantity: Number(form.quantity),
-      low_stock_alert: Boolean(form.low_stock_alert)
+      quantity: Number(form.quantity)
     })
   }
 
@@ -41,15 +39,6 @@ export default function EditInventoryModal({ item, onClose, onSave }) {
           value={form.unit}
           onChange={handleChange}
         />
-        <label className="flex items-center space-x-2">
-          <input
-            type="checkbox"
-            name="low_stock_alert"
-            checked={form.low_stock_alert}
-            onChange={handleChange}
-          />
-          <span>Enable Low Stock Alert</span>
-        </label>
         <div className="space-x-2 text-right">
           <button type="submit" className="border border-[#800000] px-2 py-1">Save</button>
           <button type="button" className="border border-[#800000] px-2 py-1" onClick={onClose}>Cancel</button>

--- a/frontend/src/pages/InventoryPage.jsx
+++ b/frontend/src/pages/InventoryPage.jsx
@@ -45,7 +45,7 @@ export default function InventoryPage() {
 
   return (
     <div className="space-y-4 text-[#FFD700]">
-      <h2 className="text-xl font-bold">Inventory</h2>
+      <h2 className="text-xl font-bold">Inventory Management</h2>
       <InventoryTable
         items={items}
         onEdit={item => setEditItem(item)}
@@ -54,7 +54,7 @@ export default function InventoryPage() {
         lowThreshold={5}
       />
       <button className="border border-[#800000] px-2 py-1" onClick={() => setShowAdd(true)}>
-        Add Item
+        Add Inventory Item
       </button>
       {showAdd && (
         <AddInventoryModal onClose={() => setShowAdd(false)} onAdd={handleAdd} />

--- a/frontend/src/supabase/inventory.js
+++ b/frontend/src/supabase/inventory.js
@@ -1,21 +1,31 @@
 import { supabase } from '../supabase'
 
+const LOW_STOCK_THRESHOLD = 5
+
 export async function getInventory() {
   const { data, error } = await supabase
     .from('inventory')
     .select('*')
-    .order('low_stock_alert', { ascending: false })
+    .order('quantity', { ascending: true })
   if (error) throw error
   return data || []
 }
 
 export async function addItem(item) {
-  const { error } = await supabase.from('inventory').insert(item)
+  const record = {
+    ...item,
+    low_stock_alert: item.quantity < LOW_STOCK_THRESHOLD
+  }
+  const { error } = await supabase.from('inventory').insert(record)
   if (error) throw error
 }
 
 export async function updateItem(id, data) {
-  const { error } = await supabase.from('inventory').update(data).eq('id', id)
+  const record = {
+    ...data,
+    low_stock_alert: data.quantity < LOW_STOCK_THRESHOLD
+  }
+  const { error } = await supabase.from('inventory').update(record).eq('id', id)
   if (error) throw error
 }
 

--- a/frontend/supabase-schema.sql
+++ b/frontend/supabase-schema.sql
@@ -17,18 +17,17 @@ create table daily_reports (
   created_at timestamp default now()
 );
 
- codex/build-smart-alerts-system-in-chefmind
 create table dismissed_alerts (
   id uuid default uuid_generate_v4() primary key,
-  message text,
-=======
+  message text
+);
+
 create table daily_tasks (
   id uuid default uuid_generate_v4() primary key,
   task text,
   shift text,
   status text default 'pending',
   staff_id uuid references staff(id),
- main
   created_at timestamp default now()
 );
 
@@ -37,5 +36,14 @@ create table shifts_schedule (
   staff_id uuid references staff(id),
   day text,
   shift text,
+  created_at timestamp default now()
+);
+
+create table inventory (
+  id uuid default uuid_generate_v4() primary key,
+  item_name text not null,
+  quantity integer not null,
+  unit text,
+  low_stock_alert boolean default false,
   created_at timestamp default now()
 );


### PR DESCRIPTION
## Summary
- clean up `supabase-schema.sql`
- add `inventory` table schema definition
- update Supabase inventory helpers to auto-set low stock alerts and order by quantity
- adjust inventory modal dialogs to remove manual low stock toggle
- rename page heading/button to "Inventory Management"

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c48bca9cc832f9caf9ad15d8bdc47