### PR TITLE
Add Daily Reports table constraints and actions

### DIFF
--- a/frontend/src/pages/DailyReports.jsx
+++ b/frontend/src/pages/DailyReports.jsx
@@ -137,10 +137,10 @@ export default function DailyReports({ onBack }) {
               {role !== 'Worker' && (
                 <td className='p-2 space-x-1'>
                   <button className='border px-1' onClick={() => startEdit(r)}>
-                    ✏️
+                    ✏️ Edit Report
                   </button>
                   <button className='border px-1' onClick={() => handleDelete(r.id)}>
-                    ❌
+                    🗑️ Delete Report
                   </button>
                 </td>
               )}
@@ -257,7 +257,7 @@ export default function DailyReports({ onBack }) {
         </form>
       ) : (
         <button className='border px-2 py-1' onClick={() => setShowForm(true)}>
-          Add Report
+          ➕ Add Daily Report
         </button>
       ))}
       <button className='border px-2 py-1' onClick={onBack}>Back</button>

--- a/frontend/supabase-schema.sql
+++ b/frontend/supabase-schema.sql
@@ -9,8 +9,8 @@ create table staff (
 
 create table daily_reports (
   id uuid default uuid_generate_v4() primary key,
-  date date,
-  shift text,
+  date date not null,
+  shift text not null,
   staff_id uuid references staff(id),
   notes text,
   issues text,


### PR DESCRIPTION
## Summary
- enforce NOT NULL on `daily_reports` table fields `date` and `shift`
- label actions on Daily Reports page
- rename button to **Add Daily Report**

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4a299e30832f996f0207ed3e75ab