### PR TITLE
Implement staff status management

### DIFF
--- a/frontend/src/components/AddStaffModal.jsx
+++ b/frontend/src/components/AddStaffModal.jsx
@@ -2,10 +2,15 @@ import { useState } from 'react'
 import { addStaff } from '../supabase/staff'
 
 export default function AddStaffModal({ isOpen, onClose, onAdded }) {
-  const [form, setForm] = useState({ name: '', role: 'Chef', shift: 'Morning' })
+  const [form, setForm] = useState({
+    name: '',
+    role: 'Chef',
+    shift: '',
+    status: 'Active'
+  })
 
-  const roles = ['Chef', 'Cashier', 'Server']
-  const shifts = ['Morning', 'Evening']
+  const roles = ['Chef', 'Cashier', 'Manager']
+  const statuses = ['Active', 'Inactive', 'Problematic']
 
   if (!isOpen) return null
 
@@ -14,15 +19,15 @@ export default function AddStaffModal({ isOpen, onClose, onAdded }) {
   }
 
   function handleCancel() {
-    setForm({ name: '', role: 'Chef', shift: 'Morning' })
+    setForm({ name: '', role: 'Chef', shift: '', status: 'Active' })
     onClose()
   }
 
   async function handleSubmit(e) {
     e.preventDefault()
-    await addStaff({ ...form, status: 'Active' })
+    await addStaff(form)
     onAdded()
-    setForm({ name: '', role: 'Chef', shift: 'Morning' })
+    setForm({ name: '', role: 'Chef', shift: '', status: 'Active' })
     onClose()
   }
 
@@ -48,13 +53,20 @@ export default function AddStaffModal({ isOpen, onClose, onAdded }) {
               <option key={r} value={r}>{r}</option>
             ))}
           </select>
-          <select
+          <input
             className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            placeholder="Shift (e.g. 11am-5pm)"
             name="shift"
             value={form.shift}
             onChange={handleChange}
+          />
+          <select
+            className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            name="status"
+            value={form.status}
+            onChange={handleChange}
           >
-            {shifts.map(s => (
+            {statuses.map(s => (
               <option key={s} value={s}>{s}</option>
             ))}
           </select>

--- a/frontend/src/components/EditStaffModal.jsx
+++ b/frontend/src/components/EditStaffModal.jsx
@@ -2,11 +2,10 @@ import { useState, useEffect } from 'react'
 import { updateStaff } from '../supabase/staff'
 
 export default function EditStaffModal({ isOpen, staff, onClose, onUpdated }) {
-  const [form, setForm] = useState({ name: '', role: 'Chef', shift: 'Morning', status: 'Active' })
+  const [form, setForm] = useState({ name: '', role: 'Chef', shift: '', status: 'Active' })
 
-  const roles = ['Chef', 'Cashier', 'Server']
-  const shifts = ['Morning', 'Evening']
-  const statuses = ['Active', 'On Leave', 'Terminated']
+  const roles = ['Chef', 'Cashier', 'Manager']
+  const statuses = ['Active', 'Inactive', 'Problematic']
 
   useEffect(() => {
     if (staff) {
@@ -58,16 +57,13 @@ export default function EditStaffModal({ isOpen, staff, onClose, onUpdated }) {
               <option key={r} value={r}>{r}</option>
             ))}
           </select>
-          <select
+          <input
             className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
+            placeholder="Shift (e.g. 11am-5pm)"
             name="shift"
             value={form.shift}
             onChange={handleChange}
-          >
-            {shifts.map(s => (
-              <option key={s} value={s}>{s}</option>
-            ))}
-          </select>
+          />
           <select
             className="border border-[#800000] bg-black text-[#FFD700] p-1 w-full"
             name="status"

--- a/frontend/src/components/StaffTable.jsx
+++ b/frontend/src/components/StaffTable.jsx
@@ -11,7 +11,7 @@ export default function StaffTable() {
   const [showAdd, setShowAdd] = useState(false)
   const [editItem, setEditItem] = useState(null)
 
-  const roleIcons = { Chef: '🍳', Cashier: '💰', Server: '🍽️' }
+  const roleIcons = { Chef: '🍳', Cashier: '💰', Manager: '👑', Server: '🍽️' }
 
   useEffect(() => {
     fetchStaff()
@@ -55,7 +55,7 @@ export default function StaffTable() {
           className="border border-[#800000] px-2 py-1"
           onClick={() => setShowAdd(true)}
         >
-          Add Staff
+          Add New Staff
         </button>
       </div>
       <table className="w-full text-left border border-[#800000]">


### PR DESCRIPTION
## Summary
- allow selecting status when adding staff
- support editing staff with new statuses
- display Manager role with icon and update Add button label

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4a8db70c832f86724e1e7cfe3c5f