### PR TITLE
Implement additional pages and export features

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,11 +8,13 @@ import InventoryPage from './pages/InventoryPage'
 import StaffPage from './pages/StaffPage'
 import ShiftScheduler from './pages/ShiftScheduler'
 import Shifts from './pages/Shifts'
- codex/add-upsell-center-page
 import UpsellCenter from './pages/UpsellCenter'
-=======
 import Offers from './pages/Offers'
- main
+import OrdersPage from './pages/OrdersPage'
+import NotificationsPage from './pages/NotificationsPage'
+import AIAssistant from './pages/AIAssistant'
+import KingControlCenter from './pages/KingControlCenter'
+import ConfigSettings from './pages/ConfigSettings'
 import Sidebar from './components/Sidebar'
 import Header from './components/Header'
 import { useRole } from './RoleContext'
@@ -38,13 +40,20 @@ function App() {
     content = <Shifts />
   } else if (page === 'schedule') {
     content = <ShiftScheduler />
- codex/add-upsell-center-page
   } else if (page === 'upsell') {
     content = <UpsellCenter />
-=======
   } else if (page === 'offers') {
     content = <Offers />
- main
+  } else if (page === 'orders') {
+    content = <OrdersPage />
+  } else if (page === 'notifications') {
+    content = <NotificationsPage />
+  } else if (page === 'ai') {
+    content = <AIAssistant />
+  } else if (page === 'king-control') {
+    content = <KingControlCenter />
+  } else if (page === 'config') {
+    content = <ConfigSettings />
   } else {
     content = <Home onViewReports={() => setPage('dailyReports')} />
   }

--- a/frontend/src/components/AddInventoryModal.jsx
+++ b/frontend/src/components/AddInventoryModal.jsx
@@ -16,12 +16,8 @@ export default function AddInventoryModal({ onClose, onAdd }) {
     e.preventDefault()
     onAdd({
       ...form,
- codex/build-inventory-management-page
       quantity: Number(form.quantity),
       low_stock_alert: Number(form.quantity) < 5
-
-      quantity: Number(form.quantity)
- main
     })
   }
 

--- a/frontend/src/components/EditInventoryModal.jsx
+++ b/frontend/src/components/EditInventoryModal.jsx
@@ -15,12 +15,8 @@ export default function EditInventoryModal({ item, onClose, onSave }) {
     e.preventDefault()
     onSave({
       ...form,
- codex/build-inventory-management-page
       quantity: Number(form.quantity),
       low_stock_alert: Number(form.quantity) < 5
-
-      quantity: Number(form.quantity)
- main
     })
   }
 

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -26,18 +26,31 @@ export default function Sidebar({ onNavigate }) {
       <button className="block" onClick={() => onNavigate('offers')}>
         Offers
       </button>
+      <button className="block" onClick={() => onNavigate('orders')}>
+        Orders
+      </button>
+      <button className="block" onClick={() => onNavigate('notifications')}>
+        Notifications
+      </button>
+      <button className="block" onClick={() => onNavigate('ai')}>
+        AI Assistant
+      </button>
       <button className="block" onClick={() => onNavigate('alerts')}>
         Alerts
       </button>
       <button className="block" onClick={() => onNavigate('tasks')}>
         Tasks
       </button>
-      <button className="block" onClick={() => onNavigate('upsell')}>
-        Upsell Center
-      </button>
-      {role === 'King' && (
-        <button className="block" onClick={() => onNavigate('king')}>Admin Panel</button>
-      )}
+  <button className="block" onClick={() => onNavigate('upsell')}>
+    Upsell Center
+  </button>
+  {role === 'King' && (
+        <>
+          <button className="block" onClick={() => onNavigate('king')}>Admin Panel</button>
+          <button className="block" onClick={() => onNavigate('king-control')}>King Control</button>
+          <button className="block" onClick={() => onNavigate('config')}>Config</button>
+        </>
+  )}
     </aside>
   )
 }

--- a/frontend/src/components/StaffTable.jsx
+++ b/frontend/src/components/StaffTable.jsx
@@ -3,6 +3,7 @@ import { getStaff, deleteStaff } from '../supabase/staff'
 import AddStaffModal from './AddStaffModal'
 import EditStaffModal from './EditStaffModal'
 import { useRole } from '../RoleContext'
+import { exportToCsv } from '../utils/export'
 
 export default function StaffTable() {
   const { role } = useRole()
@@ -56,6 +57,12 @@ export default function StaffTable() {
           onClick={() => setShowAdd(true)}
         >
           Add New Staff
+        </button>
+        <button
+          className="border border-[#800000] px-2 py-1"
+          onClick={() => exportToCsv('staff.csv', staff)}
+        >
+          Export CSV
         </button>
       </div>
       <table className="w-full text-left border border-[#800000]">

--- a/frontend/src/pages/AIAssistant.jsx
+++ b/frontend/src/pages/AIAssistant.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+import { getTopSellers } from '../supabase/upsell'
+
+export default function AIAssistant() {
+  const [top, setTop] = useState([])
+
+  useEffect(() => {
+    fetchTop()
+  }, [])
+
+  async function fetchTop() {
+    try {
+      const data = await getTopSellers()
+      setTop(data)
+    } catch (err) {
+      console.error('Failed to fetch data', err)
+    }
+  }
+
+  return (
+    <div className='space-y-4 text-[#FFD700]'>
+      <h2 className='text-xl font-bold'>Weekly Analysis</h2>
+      <p className='text-sm'>Most sold meals this week:</p>
+      <ul className='list-disc pl-6'>
+        {top.map(t => (
+          <li key={t.item}>{t.item} – {t.count}</li>
+        ))}
+      </ul>
+      <div className='border border-[#800000] p-4'>
+        Future AI suggestions will appear here.
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/ConfigSettings.jsx
+++ b/frontend/src/pages/ConfigSettings.jsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import { supabase } from '../supabase'
+
+export default function ConfigSettings() {
+  const [apiUrl, setApiUrl] = useState('')
+  const [apiKey, setApiKey] = useState('')
+
+  async function backup() {
+    try {
+      const { data: staff } = await supabase.from('staff').select('*')
+      const { data: inventory } = await supabase.from('inventory').select('*')
+      const { data: orders } = await supabase.from('orders').select('*')
+      const json = JSON.stringify({ staff, inventory, orders }, null, 2)
+      const blob = new Blob([json], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'backup.json'
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      console.error('Failed to backup', err)
+    }
+  }
+
+  return (
+    <div className='space-y-4 text-[#FFD700]'>
+      <h2 className='text-xl font-bold'>Config Settings</h2>
+      <div className='space-y-2'>
+        <input
+          className='border border-[#800000] bg-black text-[#FFD700] p-1 w-full'
+          placeholder='Supabase URL'
+          value={apiUrl}
+          onChange={e => setApiUrl(e.target.value)}
+        />
+        <input
+          className='border border-[#800000] bg-black text-[#FFD700] p-1 w-full'
+          placeholder='Supabase Key'
+          value={apiKey}
+          onChange={e => setApiKey(e.target.value)}
+        />
+      </div>
+      <button className='border border-[#800000] px-2 py-1' onClick={backup}>Download Backup</button>
+    </div>
+  )
+}

--- a/frontend/src/pages/DailyReports.jsx
+++ b/frontend/src/pages/DailyReports.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { exportToCsv } from '../utils/export'
 import { supabase } from '../supabase'
 import {
   getReports,
@@ -113,6 +114,9 @@ export default function DailyReports({ onBack }) {
   return (
     <div className='space-y-4'>
       <h2 className='text-xl font-bold'>Daily Reports</h2>
+      <button className='border border-[#800000] px-2 py-1 mb-2' onClick={() => exportToCsv('reports.csv', reports)}>
+        Export CSV
+      </button>
       <table className='w-full text-left border'>
         <thead>
           <tr className='border-b'>

--- a/frontend/src/pages/InventoryPage.jsx
+++ b/frontend/src/pages/InventoryPage.jsx
@@ -4,6 +4,7 @@ import InventoryTable from '../components/InventoryTable'
 import AddInventoryModal from '../components/AddInventoryModal'
 import EditInventoryModal from '../components/EditInventoryModal'
 import { getInventory, addItem, updateItem, deleteItem } from '../supabase/inventory'
+import { exportToCsv } from '../utils/export'
 
 export default function InventoryPage() {
   const { role } = useRole()
@@ -48,7 +49,6 @@ export default function InventoryPage() {
 
   return (
     <div className="space-y-4 text-[#FFD700]">
- codex/build-inventory-management-page
       <h2 className="text-xl font-bold">Inventory</h2>
       <label className="block">
         <input
@@ -69,9 +69,14 @@ export default function InventoryPage() {
         canDelete={role === 'King'}
         lowThreshold={5}
       />
-      <button className="border border-[#800000] px-2 py-1" onClick={() => setShowAdd(true)}>
-        Add Inventory Item
-      </button>
+      <div className="space-x-2">
+        <button className="border border-[#800000] px-2 py-1" onClick={() => setShowAdd(true)}>
+          Add Inventory Item
+        </button>
+        <button className="border border-[#800000] px-2 py-1" onClick={() => exportToCsv('inventory.csv', items)}>
+          Export CSV
+        </button>
+      </div>
       {showAdd && (
         <AddInventoryModal onClose={() => setShowAdd(false)} onAdd={handleAdd} />
       )}

--- a/frontend/src/pages/KingControlCenter.jsx
+++ b/frontend/src/pages/KingControlCenter.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react'
+import { useRole } from '../RoleContext'
+import { getStaff } from '../supabase/staff'
+import { getInventory } from '../supabase/inventory'
+import { getOrders } from '../supabase/orders'
+
+export default function KingControlCenter() {
+  const { role } = useRole()
+  const [summary, setSummary] = useState({ staff: 0, inventory: 0, orders: 0 })
+  const [enabled, setEnabled] = useState({ staff: true, inventory: true, orders: true })
+
+  useEffect(() => { if (role === 'King') load() }, [role])
+
+  async function load() {
+    const staff = await getStaff()
+    const inv = await getInventory()
+    const ord = await getOrders()
+    setSummary({ staff: staff.length, inventory: inv.length, orders: ord.length })
+  }
+
+  if (role !== 'King') return <div>You do not have access to this page.</div>
+
+  return (
+    <div className='space-y-4 text-[#FFD700]'>
+      <h2 className='text-xl font-bold'>King Control Center</h2>
+      <div className='space-y-2'>
+        <div className='flex items-center space-x-2'>
+          <label className='flex-1'>Staff ({summary.staff})</label>
+          <button className='border border-[#800000] px-2' onClick={() => setEnabled(e => ({...e, staff: !e.staff}))}>
+            {enabled.staff ? 'Disable' : 'Enable'}
+          </button>
+        </div>
+        <div className='flex items-center space-x-2'>
+          <label className='flex-1'>Inventory ({summary.inventory})</label>
+          <button className='border border-[#800000] px-2' onClick={() => setEnabled(e => ({...e, inventory: !e.inventory}))}>
+            {enabled.inventory ? 'Disable' : 'Enable'}
+          </button>
+        </div>
+        <div className='flex items-center space-x-2'>
+          <label className='flex-1'>Orders ({summary.orders})</label>
+          <button className='border border-[#800000] px-2' onClick={() => setEnabled(e => ({...e, orders: !e.orders}))}>
+            {enabled.orders ? 'Disable' : 'Enable'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/NotificationsPage.jsx
+++ b/frontend/src/pages/NotificationsPage.jsx
@@ -1,0 +1,6 @@
+import Alerts from './Alerts'
+
+export default function NotificationsPage() {
+  // Reuse Alerts logic for now
+  return <Alerts />
+}

--- a/frontend/src/pages/OrdersPage.jsx
+++ b/frontend/src/pages/OrdersPage.jsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react'
+import { getOrders, addOrder, updateOrder } from '../supabase/orders'
+import { useRole } from '../RoleContext'
+
+export default function OrdersPage() {
+  const { role } = useRole()
+  const [orders, setOrders] = useState([])
+  const [form, setForm] = useState({ customer_name: '', notes: '' })
+
+  useEffect(() => { fetchData() }, [])
+
+  async function fetchData() {
+    try {
+      const data = await getOrders()
+      setOrders(data)
+    } catch (err) {
+      console.error('Failed to fetch orders', err)
+    }
+  }
+
+  async function handleAdd(e) {
+    e.preventDefault()
+    try {
+      await addOrder({ ...form, status: 'Preparing' })
+      setForm({ customer_name: '', notes: '' })
+      fetchData()
+    } catch (err) {
+      console.error('Failed to add order', err)
+    }
+  }
+
+  async function changeStatus(id, status) {
+    try {
+      await updateOrder(id, { status })
+      fetchData()
+    } catch (err) {
+      console.error('Failed to update order', err)
+    }
+  }
+
+  function handlePrint(order) {
+    window.print()
+  }
+
+  return (
+    <div className='space-y-4 text-[#FFD700]'>
+      <h2 className='text-xl font-bold'>Orders</h2>
+      <form onSubmit={handleAdd} className='space-x-2'>
+        <input
+          className='border border-[#800000] bg-black text-[#FFD700] p-1'
+          placeholder='Customer name'
+          value={form.customer_name}
+          onChange={e => setForm({ ...form, customer_name: e.target.value })}
+        />
+        <input
+          className='border border-[#800000] bg-black text-[#FFD700] p-1'
+          placeholder='Notes'
+          value={form.notes}
+          onChange={e => setForm({ ...form, notes: e.target.value })}
+        />
+        <button className='border border-[#800000] px-2 py-1'>Create</button>
+      </form>
+      <table className='w-full text-left border border-[#800000]'>
+        <thead>
+          <tr className='border-b border-[#800000]'>
+            <th className='p-2'>Number</th>
+            <th className='p-2'>Customer</th>
+            <th className='p-2'>Status</th>
+            <th className='p-2'>Created</th>
+            <th className='p-2'>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map(o => (
+            <tr key={o.id} className='border-b border-[#800000]'>
+              <td className='p-2'>{o.order_number}</td>
+              <td className='p-2'>{o.customer_name || '-'}</td>
+              <td className='p-2'>{o.status}</td>
+              <td className='p-2'>{new Date(o.created_at).toLocaleString()}</td>
+              <td className='p-2 space-x-1'>
+                {o.status !== 'Ready' && (
+                  <button className='border border-[#800000] px-1' onClick={() => changeStatus(o.id, 'Ready')}>
+                    Mark Ready
+                  </button>
+                )}
+                {o.status !== 'Delivered' && (
+                  <button className='border border-[#800000] px-1' onClick={() => changeStatus(o.id, 'Delivered')}>
+                    Deliver
+                  </button>
+                )}
+                <button className='border border-[#800000] px-1' onClick={() => handlePrint(o)}>Print</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/supabase/inventory.js
+++ b/frontend/src/supabase/inventory.js
@@ -14,11 +14,7 @@ export async function getInventory() {
 export async function addItem(item) {
   const record = {
     ...item,
- codex/build-inventory-management-page
-    low_stock_alert: item.quantity < 5
-
     low_stock_alert: item.quantity < LOW_STOCK_THRESHOLD
- main
   }
   const { error } = await supabase.from('inventory').insert(record)
   if (error) throw error
@@ -27,11 +23,7 @@ export async function addItem(item) {
 export async function updateItem(id, data) {
   const record = {
     ...data,
- codex/build-inventory-management-page
-    low_stock_alert: data.quantity < 5
-
     low_stock_alert: data.quantity < LOW_STOCK_THRESHOLD
- main
   }
   const { error } = await supabase.from('inventory').update(record).eq('id', id)
   if (error) throw error

--- a/frontend/src/supabase/orders.js
+++ b/frontend/src/supabase/orders.js
@@ -1,0 +1,25 @@
+import { supabase } from '../supabase'
+
+export async function getOrders() {
+  const { data, error } = await supabase
+    .from('orders')
+    .select('*')
+    .order('created_at', { ascending: false })
+  if (error) throw error
+  return data || []
+}
+
+export async function addOrder(data) {
+  const { error } = await supabase.from('orders').insert(data)
+  if (error) throw error
+}
+
+export async function updateOrder(id, data) {
+  const { error } = await supabase.from('orders').update(data).eq('id', id)
+  if (error) throw error
+}
+
+export async function deleteOrder(id) {
+  const { error } = await supabase.from('orders').delete().eq('id', id)
+  if (error) throw error
+}

--- a/frontend/src/utils/export.js
+++ b/frontend/src/utils/export.js
@@ -1,0 +1,12 @@
+export function exportToCsv(filename, rows) {
+  if (!rows.length) return
+  const headers = Object.keys(rows[0])
+  const csv = [headers.join(','), ...rows.map(r => headers.map(h => JSON.stringify(r[h] ?? '')).join(','))].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary
- add AI assistant, config settings, and king control center pages
- create basic orders and notifications pages
- integrate new orders supabase helper
- allow CSV export for inventory, staff and daily reports
- clean inventory management helpers

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4ee5d624832fbe972a2f9fe2e2b0