### PR TITLE
Connect Register button to Supabase signup

### DIFF
--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState } from 'react'
-import { supabase, signIn, signUp, signOut, onAuthStateChange } from '../utils/auth'
+import { supabase } from '../supabase'
+import { onAuthStateChange } from '../utils/auth'
 
 interface AuthContextProps {
   user: any
@@ -28,15 +29,35 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [])
 
   const login = async (email: string, password: string) => {
-    await signIn(email, password)
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error) throw error
   }
 
   const register = async (email: string, password: string) => {
-    await signUp(email, password)
+    try {
+      const { data, error } = await supabase.auth.signUp({
+        email,
+        password,
+      })
+
+      if (error) {
+        console.error('❌ Registration Error:', error.message)
+        alert('❌ Failed to register: ' + error.message)
+        return
+      }
+
+      alert(
+        '✅ Registration successful! Please check your email to verify your account.'
+      )
+    } catch (err) {
+      console.error('❌ Unexpected error:', err)
+      alert('❌ Something went wrong during registration.')
+    }
   }
 
   const logout = async () => {
-    await signOut()
+    const { error } = await supabase.auth.signOut()
+    if (error) throw error
   }
 
   return (

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -35,7 +35,10 @@ export default function Register() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
-        <button className="bg-gold text-black px-4 py-2 rounded hover:scale-105 transition-transform">
+        <button
+          className="bg-yellow-500 hover:bg-yellow-600 text-black px-4 py-2 rounded"
+          onClick={() => register(email, password)}
+        >
           Register
         </button>
       </form>


### PR DESCRIPTION
## Summary
- update `useAuth` to handle registration via Supabase and display alerts
- style and connect Register button in `register.tsx`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e1c1228c4832faad8584a138a401e