### PR TITLE
fix: auth/register-confirm flow with Supabase

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@supabase/supabase-js": "^2.39.6"
+    "@supabase/supabase-js": "^2.39.6",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "vite": "^5.2.10",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,10 @@ function App() {
     return <Login />
   }
 
+  if (!user.confirmed_at) {
+    return <p className='text-white'>Please verify your email to access the app.</p>
+  }
+
   let content
   if (role === 'King' && page === 'king') {
     content = <KingDashboard />

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -34,33 +34,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }
 
   const register = async (email: string, password: string) => {
-    if (!email.includes('@') || !email.includes('.')) {
-      alert('Please enter a valid email address')
+    if (!email || !password) {
+      alert('❌ Please enter all fields')
       return
     }
 
-    if (password.length < 6) {
-      alert('Password must be at least 6 characters')
+    const { error } = await supabase.auth.signUp({ email, password })
+
+    if (error) {
+      alert(`❌ Failed to register: ${error.message}`)
       return
     }
 
-    try {
-      const { data, error } = await supabase.auth.signUp({ email, password })
-
-      if (error) {
-        console.error('❌ Registration Error:', error.message)
-        alert('❌ Failed to register: ' + error.message)
-        return
-      }
-
-      console.log('Registration response:', data)
-      alert(
-        '✅ Registration successful! Please check your email to verify your account.'
-      )
-    } catch (err) {
-      console.error('❌ Unexpected error:', err)
-      alert('❌ Something went wrong during registration.')
-    }
+    alert('✅ Registration successful! Please check your email to verify your account.')
   }
 
   const logout = async () => {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,13 +3,20 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import { RoleProvider } from './RoleContext'
 import { AuthProvider } from './hooks/useAuth'
+import Confirm from './pages/Confirm'
 import './index.css'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <AuthProvider>
       <RoleProvider>
-        <App />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/confirm" element={<Confirm />} />
+            <Route path="*" element={<App />} />
+          </Routes>
+        </BrowserRouter>
       </RoleProvider>
     </AuthProvider>
   </React.StrictMode>,

--- a/frontend/src/pages/Confirm.jsx
+++ b/frontend/src/pages/Confirm.jsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react'
+import { supabase } from '../supabase'
+
+export default function Confirm() {
+  useEffect(() => {
+    const finish = async () => {
+      await supabase.auth.getSession()
+      const {
+        data: { user }
+      } = await supabase.auth.getUser()
+      if (user) {
+        await supabase.from('users').insert([
+          { uid: user.id, email: user.email }
+        ])
+      }
+      window.location.replace('/')
+    }
+    finish()
+  }, [])
+  return <p className='text-white'>🔄 Verifying your account…</p>
+}

--- a/frontend/src/pages/register.tsx
+++ b/frontend/src/pages/register.tsx
@@ -36,8 +36,8 @@ export default function Register() {
           onChange={(e) => setPassword(e.target.value)}
         />
         <button
+          type="submit"
           className="bg-yellow-500 hover:bg-yellow-600 text-black px-4 py-2 rounded"
-          onClick={() => register(email, password)}
         >
           Register
         </button>

--- a/frontend/supabase-schema.sql
+++ b/frontend/supabase-schema.sql
@@ -1,5 +1,6 @@
 create table users (
-  id uuid primary key references auth.users(id),
+  uid uuid primary key references auth.users(id),
+  email text,
   role text default 'staff'
 );
 -- policies will limit insert/select/update based on role value
@@ -113,3 +114,11 @@ create table inventory (
   created_at timestamp default now()
  main
 );
+
+-- Enable row level security for users table
+alter table users enable row level security;
+
+create policy "Allow insert for authenticated users"
+on users for insert
+to authenticated
+using (auth.uid() = uid);


### PR DESCRIPTION
## Summary
- finalize Supabase auth flow
- add `/confirm` page
- use React Router for confirmation page
- ensure users table allows row-level inserts
- show warning when email is not verified

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3000c0b4832f86ca39d2e537f94e