### PR TITLE
Add setup script and postinstall hook

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "postinstall": "./setup.sh"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/frontend/setup.sh
+++ b/frontend/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "🔧 Installing dependencies..."
+npm install
+echo "🔧 Generating Supabase types..."
+npx supabase gen types typescript --local
+echo "✅ Setup complete."


### PR DESCRIPTION
## Summary
- add `setup.sh` for installing dependencies and generating Supabase types
- run the new setup script automatically using `postinstall`

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68705d7fdcd8832f9f7a36f76fa217d6