### PR TITLE
Add king role assignment script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "postinstall": ""
+    "postinstall": "",
+    "assign-king": "node scripts/assignKingRole.js"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/frontend/scripts/assignKingRole.js
+++ b/frontend/scripts/assignKingRole.js
@@ -1,0 +1,43 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+async function assignKingRole() {
+  const email = 'h.b.k.ayhm@gmail.com'
+
+  // Get user ID via Admin API
+  const { data: { user }, error: getUserError } = await supabase.auth.admin.getUserByEmail(email)
+
+  if (getUserError || !user) {
+    console.error('❌ Failed to fetch user:', getUserError)
+    return
+  }
+
+  // Update role in auth.users via Admin API
+  const { error: userUpdateError } = await supabase.auth.admin.updateUserById(user.id, {
+    role: 'king'
+  })
+
+  if (userUpdateError) {
+    console.error('❌ Failed to update role in auth.users:', userUpdateError)
+  } else {
+    console.log('✅ Role updated to king in auth.users')
+  }
+
+  // Update role in staff table if present
+  const { error: staffUpdateError } = await supabase
+    .from('staff')
+    .update({ role: 'king' })
+    .eq('email', email)
+
+  if (staffUpdateError) {
+    console.error('❌ Failed to update role in staff:', staffUpdateError)
+  } else {
+    console.log('✅ Role updated to king in staff')
+  }
+}
+
+assignKingRole()


### PR DESCRIPTION
## Summary
- add a small Node script to grant the `king` role
- wire script into npm scripts

## Testing
- `npm run assign-king` *(fails: Cannot find package '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_6870b55e65b4832f8786a69bc157f4c1