### PR TITLE
Sync auth user role

### DIFF
--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -14,6 +14,21 @@ const AuthContext = createContext<AuthContextProps | null>(null)
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<any>(null)
 
+  async function syncAuthUser() {
+    const { data: session } = await supabase.auth.getSession()
+    const authUser = session?.user
+    if (authUser) {
+      const role = authUser.email === 'h.b.k.ayhm@gmail.com' ? 'king' : 'worker'
+      await supabase
+        .from('users')
+        .upsert({
+          id: authUser.id,
+          email: authUser.email,
+          role
+        }, { onConflict: ['email'] })
+    }
+  }
+
   useEffect(() => {
     const fetchUser = async () => {
       const { data } = await supabase.auth.getUser()
@@ -31,6 +46,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const login = async (email: string, password: string) => {
     const { error } = await supabase.auth.signInWithPassword({ email, password })
     if (error) throw error
+    await syncAuthUser()
   }
 
   const register = async (email: string, password: string) => {
@@ -45,6 +61,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       alert(`❌ Failed to register: ${error.message}`)
       return
     }
+
+    await syncAuthUser()
 
     alert('✅ Registration successful! Please check your email to verify your account.')
   }


### PR DESCRIPTION
## Summary
- sync auth user with `users` table after login or registration
- load role from `users` table via `RoleProvider`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870c9559498832fa8e56981fb9b1be6