### PR TITLE
Implement smart auth routing and navbar

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,26 +16,17 @@ import AIAssistant from './pages/AIAssistant'
 import KingControlCenter from './pages/KingControlCenter'
 import ConfigSettings from './pages/ConfigSettings'
 import Sidebar from './components/Sidebar'
-import Header from './components/Header'
+import Navbar from './components/Navbar'
 import { useRole } from './RoleContext'
 import { useAuth } from './hooks/useAuth'
 import { KING_ID } from './constants'
-import Login from './pages/login'
-import Register from './pages/register'
 
 function App() {
   const { role } = useRole()
   const { user } = useAuth()
   const [page, setPage] = useState('home')
 
-  if (!user) {
-    if (location.hash === '#register') {
-      return <Register />
-    }
-    return <Login />
-  }
-
-  if (!user.confirmed_at) {
+  if (!user?.confirmed_at) {
     return <p className='text-white'>Please verify your email to access the app.</p>
   }
 
@@ -78,7 +69,7 @@ function App() {
     <div className='p-6 min-h-screen flex'>
       <Sidebar onNavigate={setPage} />
       <div className='flex-1'>
-        <Header />
+        <Navbar />
         {content}
       </div>
     </div>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,29 @@
+import { useRole } from '../RoleContext'
+import { useAuth } from '../hooks/useAuth'
+import { KING_ID } from '../constants'
+
+export default function Navbar() {
+  const { role } = useRole()
+  const { user, logout } = useAuth()
+
+  const identity = role === 'king'
+    ? '👑 الملك'
+    : user
+      ? `👷 ${user.email}`
+      : ''
+
+  return (
+    <header className="mb-4 flex justify-between items-center card-royal">
+      <h1 className="text-xl font-bold text-gold">ChefMind</h1>
+      <div className="space-x-2 text-sm flex items-center">
+        {identity && <span>{identity}</span>}
+        {user && (
+          <button onClick={logout} className="btn-royal">Logout</button>
+        )}
+        {user?.id === KING_ID && (
+          <button className="btn-royal">Settings</button>
+        )}
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { supabase } from '../supabase'
 import { onAuthStateChange } from '../utils/auth'
 
@@ -13,6 +14,7 @@ const AuthContext = createContext<AuthContextProps | null>(null)
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<any>(null)
+  const navigate = useNavigate()
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -31,6 +33,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const login = async (email: string, password: string) => {
     const { error } = await supabase.auth.signInWithPassword({ email, password })
     if (error) throw error
+    navigate('/dashboard')
   }
 
   const register = async (email: string, password: string) => {
@@ -47,11 +50,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
 
     alert('✅ Registration successful! Please check your email to verify your account.')
+    navigate('/dashboard')
   }
 
   const logout = async () => {
     const { error } = await supabase.auth.signOut()
     if (error) throw error
+    navigate('/login')
   }
 
   return (

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,21 +1,17 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App'
+import AppRoutes from './routes'
 import { RoleProvider } from './RoleContext'
 import { AuthProvider } from './hooks/useAuth'
-import Confirm from './pages/Confirm'
 import './index.css'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <AuthProvider>
       <RoleProvider>
         <BrowserRouter>
-          <Routes>
-            <Route path="/confirm" element={<Confirm />} />
-            <Route path="*" element={<App />} />
-          </Routes>
+          <AppRoutes />
         </BrowserRouter>
       </RoleProvider>
     </AuthProvider>

--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -1,0 +1,32 @@
+import { Routes, Route, Navigate } from 'react-router-dom'
+import { useAuth } from './hooks/useAuth'
+import Confirm from './pages/Confirm'
+import Login from './pages/login'
+import Register from './pages/register'
+import App from './App'
+
+export default function AppRoutes() {
+  const { user } = useAuth()
+  return (
+    <Routes>
+      <Route path="/confirm" element={<Confirm />} />
+      <Route
+        path="/login"
+        element={user ? <Navigate to="/dashboard" replace /> : <Login />}
+      />
+      <Route
+        path="/register"
+        element={user ? <Navigate to="/dashboard" replace /> : <Register />}
+      />
+      <Route
+        path="/dashboard/*"
+        element={user ? <App /> : <Navigate to="/login" replace />}
+      />
+      <Route
+        path="/"
+        element={<Navigate to={user ? '/dashboard' : '/login'} replace />}
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  )
+}


### PR DESCRIPTION
## Summary
- add reactive routes for login/register/dashboard
- show new Navbar with user identity and logout
- redirect on auth actions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870cbc44654832fbc86256cce4a1257