### PR TITLE
Fix context usage checks

### DIFF
--- a/frontend/src/RoleContext.tsx
+++ b/frontend/src/RoleContext.tsx
@@ -55,12 +55,13 @@ export const RoleProvider = ({ children }: { children: ReactNode }) => {
 };
 
 export const useRole = (): RoleContextType => {
-  const context = useContext(RoleContext);
+  const context = useContext(RoleContext)
   if (!context) {
-    throw new Error('useRole must be used within a RoleProvider');
+    console.error('useRole must be used within a RoleProvider')
+    return { role: 'anon', setRole: () => {} }
   }
-  return context;
-};
+  return context
+}
 
 // ========= src/hooks/useAuth.tsx =========
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';

--- a/frontend/src/pages/Alerts.jsx
+++ b/frontend/src/pages/Alerts.jsx
@@ -9,6 +9,8 @@ export default function Alerts() {
   const { user } = useAuth()
   const [alerts, setAlerts] = useState([])
 
+  if (user === null) return <p className='text-white'>Loading...</p>
+
   async function fetchAlerts() {
     // fetch dismissed alerts
     const { data: dismissedData } = await supabase

--- a/frontend/src/pages/DailyTasks.jsx
+++ b/frontend/src/pages/DailyTasks.jsx
@@ -7,6 +7,7 @@ import { KING_ID } from '../constants'
 export default function DailyTasks() {
   const { role, name } = useRole()
   const { user } = useAuth()
+  if (user === null) return <p className='text-white'>Loading...</p>
   const [tasks, setTasks] = useState([])
   const [staff, setStaff] = useState([])
   const [showForm, setShowForm] = useState(false)

--- a/frontend/src/pages/InventoryPage.jsx
+++ b/frontend/src/pages/InventoryPage.jsx
@@ -11,6 +11,7 @@ import { exportToCsv } from '../utils/export'
 export default function InventoryPage() {
   const { role } = useRole()
   const { user } = useAuth()
+  if (user === null) return <p className='text-white'>Loading...</p>
   const [items, setItems] = useState([])
   const [showAdd, setShowAdd] = useState(false)
   const [editItem, setEditItem] = useState(null)

--- a/frontend/src/pages/KingControlCenter.jsx
+++ b/frontend/src/pages/KingControlCenter.jsx
@@ -9,6 +9,7 @@ import { getOrders } from '../supabase/orders'
 export default function KingControlCenter() {
   const { role } = useRole()
   const { user } = useAuth()
+  if (user === null) return <p className='text-white'>Loading...</p>
   const [summary, setSummary] = useState({ staff: 0, inventory: 0, orders: 0 })
   const [enabled, setEnabled] = useState({ staff: true, inventory: true, orders: true })
 

--- a/frontend/src/pages/KingDashboard.tsx
+++ b/frontend/src/pages/KingDashboard.tsx
@@ -7,6 +7,8 @@ export default function KingDashboard() {
   const { role } = useRole()
   const { user } = useAuth()
 
+  if (user === null) return <p className="text-white">Loading...</p>
+
   if (user?.id !== KING_ID) {
     return <div>You do not have access to this page.</div>
   }

--- a/frontend/src/pages/inventory/InventoryPage.tsx
+++ b/frontend/src/pages/inventory/InventoryPage.tsx
@@ -16,6 +16,7 @@ interface InventoryItem {
 export default function InventoryPage() {
   const { role } = useRole()
   const { user } = useAuth()
+  if (user === null) return <p className="text-white">Loading...</p>
   const [items, setItems] = useState<InventoryItem[]>([])
   const [search, setSearch] = useState('')
   const [lowOnly, setLowOnly] = useState(false)


### PR DESCRIPTION
## Summary
- ensure RoleContext hook returns default when no provider
- guard pages using `useAuth` with a loading state

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717b14cb88832fa2bff9135747db24