### PR TITLE
Fix Supabase env usage and add king role helpers

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,8 +25,19 @@ their own tasks.
 
 ### Royal Mode
 
-Set `VITE_KING_PASSWORD` in your `.env` to enable the hidden admin panel. The SQL below
-creates the log table used for recording royal actions:
+Set `VITE_KING_PASSWORD` in your `.env` to enable the hidden admin panel.
+The email which receives the `king` role can be configured via
+`VITE_KING_EMAIL` (or `NEXT_PUBLIC_KING_EMAIL`). You can assign the role on
+Supabase by running:
+
+```bash
+npm run assign-king
+```
+
+Make sure `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` and the king email are set
+as environment variables when running the script.
+
+The SQL below creates the log table used for recording royal actions:
 
 ```sql
 create table king_activity_log (

--- a/frontend/scripts/assignKingRole.js
+++ b/frontend/scripts/assignKingRole.js
@@ -6,7 +6,11 @@ const supabase = createClient(
 )
 
 async function assignKingRole() {
-  const email = 'ayham.elmandil@gmail.com'
+  const email =
+    process.env.KING_EMAIL ||
+    process.env.NEXT_PUBLIC_KING_EMAIL ||
+    process.env.VITE_KING_EMAIL ||
+    'ayham.elmandil@gmail.com'
 
   // Get user ID via Admin API
   const { data: { user }, error: getUserError } = await supabase.auth.admin.getUserByEmail(email)

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -3,6 +3,15 @@ import { useNavigate } from 'react-router-dom'
 import { supabase } from '../lib/supabase'
 import { onAuthStateChange } from '../utils/auth'
 
+// Determine which email should have the KING role. This falls back to the
+// original hard coded address if no environment variable is provided.
+const KING_EMAIL =
+  import.meta.env.NEXT_PUBLIC_KING_EMAIL ||
+  import.meta.env.VITE_KING_EMAIL ||
+  (typeof process !== 'undefined'
+    ? (process as any).env.KING_EMAIL
+    : 'ayham.elmandil@gmail.com')
+
 interface AuthContextProps {
   user: any
   login: (email: string, password: string) => Promise<void>
@@ -21,8 +30,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const { data: session } = await supabase.auth.getSession()
       const authUser = session?.user
       if (authUser) {
-        const role =
-          authUser.email === 'ayham.elmandil@gmail.com' ? 'king' : 'worker'
+        const role = authUser.email === KING_EMAIL ? 'king' : 'worker'
 
         const { data: existing } = await supabase
           .from('users')
@@ -37,7 +45,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             role
           })
         } else if (
-          !(existing.role === 'king' && authUser.email !== 'ayham.elmandil@gmail.com')
+          !(existing.role === 'king' && authUser.email !== KING_EMAIL)
         ) {
           await supabase
             .from('users')

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1,10 +1,20 @@
 import { createClient } from '@supabase/supabase-js'
 
+// Support multiple environment variable names so the client works locally and
+// when deployed (e.g. on Vercel). We check the usual `VITE_`/`NEXT_PUBLIC_`
+// prefixed variables first, then fall back to plain names that may be defined
+// for Node scripts or other environments.
 const supabaseUrl =
-  import.meta.env.NEXT_PUBLIC_SUPABASE_URL ?? import.meta.env.VITE_SUPABASE_URL
+  import.meta.env.NEXT_PUBLIC_SUPABASE_URL ||
+  import.meta.env.VITE_SUPABASE_URL ||
+  (typeof process !== 'undefined' ? (process as any).env.SUPABASE_URL : undefined)
+
 const supabaseAnonKey =
-  import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
-  import.meta.env.VITE_SUPABASE_ANON_KEY
+  import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  import.meta.env.VITE_SUPABASE_ANON_KEY ||
+  (typeof process !== 'undefined'
+    ? (process as any).env.SUPABASE_KEY
+    : undefined)
 
 const globalAny = globalThis as any
 

--- a/frontend/src/pages/logout.tsx
+++ b/frontend/src/pages/logout.tsx
@@ -1,12 +1,17 @@
 import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 
 export default function Logout() {
-  const { logout } = useAuth()
+  const { user, logout } = useAuth()
+  const navigate = useNavigate()
 
   useEffect(() => {
-    logout()
-  }, [logout])
+    // Trigger sign out then redirect once complete.
+    logout().finally(() => {
+      navigate(user ? '/dashboard' : '/login', { replace: true })
+    })
+  }, [logout, navigate, user])
 
   return <p className="text-white">Logging out...</p>
 }


### PR DESCRIPTION
## Summary
- support SUPABASE env vars for local and deployed builds
- make king email configurable and update role logic
- update role assignment script to read env vars
- improve logout redirection
- document how to assign king role in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717e909ad4832fb003ef050c8f103d