### PR TITLE
Fix Vite build eval usage

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,4 +3,14 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    target: 'esnext',
+    minify: 'esbuild',
+  },
+  esbuild: {
+    legalComments: 'none',
+  },
+  define: {
+    'process.env': {},
+  },
 })


### PR DESCRIPTION
## Summary
- disable eval in Vite build by forcing esbuild
- ensure process.env is empty for CSP compliance

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687230d4f668832fbf71f2665f840dc6