### PR TITLE
Disable module preload polyfill

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,6 +6,12 @@ export default defineConfig({
   build: {
     target: 'esnext',
     minify: 'esbuild',
+    // Disable the module preload polyfill because it relies on
+    // `new Function` which is blocked in strict CSP environments
+    // like Vercel by default.
+    modulePreload: {
+      polyfill: false,
+    },
   },
   esbuild: {
     legalComments: 'none',


### PR DESCRIPTION
## Summary
- update `vite.config.js` to disable the module preload polyfill

This avoids injecting code which relies on `new Function`, keeping the built JS compatible with strict CSP environments such as Vercel.

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687234ce6c00832fb6a9cbe1a7e2c173