### PR TITLE
Fix reference error by removing stray text

### DIFF
--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -4,12 +4,8 @@ import { supabase } from '../lib/supabase'
 import { onAuthStateChange } from '../utils/auth'
 
 // Temporarily disable KING role logic
- jime3v-codex/deactivate-king-role-temporarily
-const KING_EMAIL = ''
-const isKing = true
 // const KING_EMAIL = ''
 // const isKing = true
- main
 
 interface AuthContextProps {
   user: any

--- a/frontend/src/pages/InventoryPage.jsx
+++ b/frontend/src/pages/InventoryPage.jsx
@@ -64,7 +64,6 @@ export default function InventoryPage() {
       </label>
 
       <h2 className="text-xl font-bold">Inventory Management</h2>
- main
       <InventoryTable
         items={displayed}
         onEdit={item => setEditItem(item)}


### PR DESCRIPTION
## Summary
- clean up leftover merge artifacts in `useAuth.tsx`
- remove stray line in `InventoryPage.jsx`

These stray tokens ended up in the bundled build and caused runtime `ReferenceError` messages.

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a4624394832f86d8822c26603500