### PR TITLE
Add script to detect unsafe eval usage

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "postinstall": ""
+    "postinstall": "",
+    "check:unsafe": "node ../scripts/find-unsafe.js"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/scripts/find-unsafe.js
+++ b/scripts/find-unsafe.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+function scan(dir, patterns, results = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'scripts') continue;
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      scan(p, patterns, results);
+    } else {
+      const text = fs.readFileSync(p, 'utf8');
+      for (const pat of patterns) {
+        if (pat.regex.test(text)) {
+          results.push(`${p}: ${pat.name}`);
+        }
+      }
+    }
+  }
+  return results;
+}
+
+const patterns = [
+  { name: 'eval(', regex: /eval\s*\(/ },
+  { name: 'new Function', regex: /new\s+Function\s*\(/ },
+  { name: 'setTimeout(string)', regex: /setTimeout\s*\(\s*['"]/ },
+  { name: 'setInterval(string)', regex: /setInterval\s*\(\s*['"]/ },
+];
+
+const results = scan(path.resolve(__dirname, '..'), patterns);
+
+if (results.length === 0) {
+  console.log('No unsafe patterns found.');
+} else {
+  for (const line of results) {
+    console.log(line);
+  }
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add a scanner script to detect `eval` or `new Function` style patterns
- expose `check:unsafe` npm command

## Testing
- `node scripts/find-unsafe.js`


------
https://chatgpt.com/codex/tasks/task_e_6872a9eb6820832fb0281b8c4ddfa302