### PR TITLE
Implement role-based access control

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,13 +17,14 @@ import KingControlCenter from './pages/KingControlCenter'
 import ConfigSettings from './pages/ConfigSettings'
 import Sidebar from './components/Sidebar'
 import Header from './components/Header'
-import { useRole } from './RoleContext'
+import { useRole, usePermissions } from './RoleContext'
 import { useAuth } from './hooks/useAuth'
 import Login from './pages/login'
 import Register from './pages/register'
 
 function App() {
   const { role } = useRole()
+  const { isKing, canAccessPage } = usePermissions()
   const { user } = useAuth()
   const [page, setPage] = useState('home')
 
@@ -39,7 +40,7 @@ function App() {
   }
 
   let content
-  if (role === 'King' && page === 'king') {
+  if (isKing() && page === 'king') {
     content = <KingDashboard />
   } else if (page === 'dailyReports') {
     content = <DailyReports onBack={() => setPage('home')} />

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,14 +1,15 @@
-import { useRole } from '../RoleContext'
+import { useRole, usePermissions } from '../RoleContext'
 
 export default function Header() {
   const { role } = useRole()
+  const { isKing } = usePermissions()
 
   return (
     <header className="mb-4 flex justify-between items-center card-royal">
       <h1 className="text-xl font-bold text-gold">ChefMind</h1>
       <div className="space-x-2 text-sm">
         <span>Role: {role}</span>
-        {role === 'King' && (
+        {isKing() && (
           <button className="btn-royal">Settings</button>
         )}
       </div>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,7 +1,8 @@
-import { useRole } from '../RoleContext'
+import { useRole, usePermissions } from '../RoleContext'
 
 export default function Sidebar({ onNavigate }) {
   const { role } = useRole()
+  const { isKing } = usePermissions()
 
   return (
     <aside className="space-y-2 mr-4 p-4 card-royal">
@@ -44,7 +45,7 @@ export default function Sidebar({ onNavigate }) {
       <button className="block btn-royal w-full" onClick={() => onNavigate('upsell')}>
         Upsell Center
       </button>
-      {role === 'King' && (
+      {isKing() && (
         <>
           <button className="block btn-royal w-full" onClick={() => onNavigate('king')}>Admin Panel</button>
           <button className="block btn-royal w-full" onClick={() => onNavigate('king-control')}>King Control</button>

--- a/frontend/src/components/StaffTable.jsx
+++ b/frontend/src/components/StaffTable.jsx
@@ -2,11 +2,12 @@ import { useEffect, useState, Fragment } from 'react'
 import { getStaff, deleteStaff } from '../supabase/staff'
 import AddStaffModal from './AddStaffModal'
 import EditStaffModal from './EditStaffModal'
-import { useRole } from '../RoleContext'
+import { useRole, usePermissions } from '../RoleContext'
 import { exportToCsv } from '../utils/export'
 
 export default function StaffTable() {
   const { role } = useRole()
+  const { isKing } = usePermissions()
   const [staff, setStaff] = useState([])
   const [filters, setFilters] = useState({ status: '' })
   const [showAdd, setShowAdd] = useState(false)
@@ -99,7 +100,7 @@ export default function StaffTable() {
                     >
                       Edit
                     </button>
-                    {role === 'King' && (
+                    {isKing() && (
                       <button
                         className="border border-[#800000] px-1"
                         onClick={() => handleDelete(s.id)}

--- a/frontend/src/pages/Alerts.jsx
+++ b/frontend/src/pages/Alerts.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../supabase'
-import { useRole } from '../RoleContext'
+import { useRole, usePermissions } from '../RoleContext'
 
 export default function Alerts() {
   const { role } = useRole()
+  const { isKing } = usePermissions()
   const [alerts, setAlerts] = useState([])
 
   async function fetchAlerts() {
@@ -78,7 +79,7 @@ export default function Alerts() {
                 {a.type} – {new Date(a.created_at).toLocaleString()}
               </div>
             </div>
-            {role === 'King' && (
+            {isKing() && (
               <button
                 className='border px-2 py-1'
                 onClick={() => dismissAlert(a)}

--- a/frontend/src/pages/DailyTasks.jsx
+++ b/frontend/src/pages/DailyTasks.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../supabase'
-import { useRole } from '../RoleContext'
+import { useRole, usePermissions } from '../RoleContext'
 
 export default function DailyTasks() {
   const { role, name } = useRole()
+  const { isKing } = usePermissions()
   const [tasks, setTasks] = useState([])
   const [staff, setStaff] = useState([])
   const [showForm, setShowForm] = useState(false)
@@ -58,7 +59,7 @@ export default function DailyTasks() {
     fetchTasks()
   }
 
-  const canEdit = role === 'King'
+  const canEdit = isKing()
 
   return (
     <div className="space-y-4 text-[#FFD700]">

--- a/frontend/src/pages/InventoryPage.jsx
+++ b/frontend/src/pages/InventoryPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useRole } from '../RoleContext'
+import { useRole, usePermissions } from '../RoleContext'
 import InventoryTable from '../components/InventoryTable'
 import AddInventoryModal from '../components/AddInventoryModal'
 import EditInventoryModal from '../components/EditInventoryModal'
@@ -8,6 +8,7 @@ import { exportToCsv } from '../utils/export'
 
 export default function InventoryPage() {
   const { role } = useRole()
+  const { isKing, canAccessPage } = usePermissions()
   const [items, setItems] = useState([])
   const [showAdd, setShowAdd] = useState(false)
   const [editItem, setEditItem] = useState(null)
@@ -66,7 +67,7 @@ export default function InventoryPage() {
         items={displayed}
         onEdit={item => setEditItem(item)}
         onDelete={handleDelete}
-        canDelete={role === 'King'}
+        canDelete={isKing()}
         lowThreshold={5}
       />
       <div className="space-x-2">

--- a/frontend/src/pages/KingControlCenter.jsx
+++ b/frontend/src/pages/KingControlCenter.jsx
@@ -1,15 +1,16 @@
 import { useEffect, useState } from 'react'
-import { useRole } from '../RoleContext'
+import { useRole, usePermissions } from '../RoleContext'
 import { getStaff } from '../supabase/staff'
 import { getInventory } from '../supabase/inventory'
 import { getOrders } from '../supabase/orders'
 
 export default function KingControlCenter() {
   const { role } = useRole()
+  const { isKing } = usePermissions()
   const [summary, setSummary] = useState({ staff: 0, inventory: 0, orders: 0 })
   const [enabled, setEnabled] = useState({ staff: true, inventory: true, orders: true })
 
-  useEffect(() => { if (role === 'King') load() }, [role])
+  useEffect(() => { if (isKing()) load() }, [role])
 
   async function load() {
     const staff = await getStaff()
@@ -18,7 +19,7 @@ export default function KingControlCenter() {
     setSummary({ staff: staff.length, inventory: inv.length, orders: ord.length })
   }
 
-  if (role !== 'King') return <div>You do not have access to this page.</div>
+  if (!isKing()) return <div>You do not have access to this page.</div>
 
   return (
     <div className='space-y-4 text-[#FFD700]'>

--- a/frontend/src/pages/KingDashboard.tsx
+++ b/frontend/src/pages/KingDashboard.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { useRole } from '../RoleContext'
+import { useRole, usePermissions } from '../RoleContext'
 
 export default function KingDashboard() {
   const { role } = useRole()
+  const { isKing } = usePermissions()
 
-  if (role !== 'King') {
+  if (!isKing()) {
     return <div>You do not have access to this page.</div>
   }
 

--- a/frontend/src/pages/inventory/InventoryPage.tsx
+++ b/frontend/src/pages/inventory/InventoryPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useRole } from '../../RoleContext'
+import { useRole, usePermissions } from '../../RoleContext'
 import { getInventory } from '../../supabase/inventory'
 
 interface InventoryItem {
@@ -13,6 +13,7 @@ interface InventoryItem {
 
 export default function InventoryPage() {
   const { role } = useRole()
+  const { isKing } = usePermissions()
   const [items, setItems] = useState<InventoryItem[]>([])
   const [search, setSearch] = useState('')
   const [lowOnly, setLowOnly] = useState(false)
@@ -31,7 +32,7 @@ export default function InventoryPage() {
     fetchData()
   }, [])
 
-  if (role !== 'King') {
+  if (!isKing()) {
     return (
       <div className="text-[#FFD700]">You do not have access to this page.</div>
     )

--- a/frontend/supabase-schema.sql
+++ b/frontend/supabase-schema.sql
@@ -1,9 +1,13 @@
+create table roles (
+  id serial primary key,
+  name text not null unique
+);
+
 create table users (
   uid uuid primary key references auth.users(id),
   email text,
-  role text default 'staff'
+  role_id integer references roles(id)
 );
--- policies will limit insert/select/update based on role value
 
 create table staff (
   id uuid default uuid_generate_v4() primary key,
@@ -24,23 +28,12 @@ create table daily_reports (
   created_at timestamp default now()
 );
 
- codex/create-and-link-offers-page
 create table dismissed_alerts (
   id uuid default uuid_generate_v4() primary key,
   message text,
   created_at timestamp default now()
 );
 
-=======
- codex/build-inventory-management-page
-=======
-create table dismissed_alerts (
-  id uuid default uuid_generate_v4() primary key,
-  message text
-);
-
- main
- main
 create table daily_tasks (
   id uuid default uuid_generate_v4() primary key,
   task text,
@@ -58,8 +51,6 @@ create table shifts_schedule (
   created_at timestamp default now()
 );
 
- codex/create-orders-and-order_items-tables-in-supabase
--- codex/create-orders-tables
 create table orders (
   id uuid default uuid_generate_v4() primary key,
   order_number serial,
@@ -76,8 +67,8 @@ create table order_items (
   menu_item_id uuid references menu_items(id),
   quantity integer default 1,
   special_request text
-=======
- codex/add-upsell-center-page
+);
+
 create table upsell_items (
   id uuid default uuid_generate_v4() primary key,
   title text,
@@ -91,9 +82,9 @@ create table upsell_items (
 create table daily_notes (
   id uuid default uuid_generate_v4() primary key,
   note text,
-  date date,
-=======
- codex/create-and-link-offers-page
+  date date
+);
+
 create table offers (
   id uuid default uuid_generate_v4() primary key,
   title text not null,
@@ -101,21 +92,18 @@ create table offers (
   discount_percent integer,
   valid_from date,
   valid_to date,
-  is_active boolean default true,
-=======
+  is_active boolean default true
+);
+
 create table inventory (
   id uuid default uuid_generate_v4() primary key,
   item_name text not null,
   quantity integer not null,
   unit text,
   low_stock_alert boolean default false,
- main
- main
   created_at timestamp default now()
- main
 );
 
--- Enable row level security for users table
 alter table users enable row level security;
 
 create policy "Allow insert for authenticated users"


### PR DESCRIPTION
## Summary
- add `roles` table and link users via `role_id`
- fetch user role from database in `RoleProvider`
- provide helper `usePermissions` with `isKing`, `canAccessPage` and `getUserPermissions`
- enforce King checks across UI components
- clean up Supabase schema

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874009f6450832f836cf7422c1fb8a0