### PR TITLE
Fix user references and policies

### DIFF
--- a/frontend/src/RoleContext.tsx
+++ b/frontend/src/RoleContext.tsx
@@ -27,7 +27,7 @@ export const RoleProvider = ({ children }: { children: ReactNode }) => {
       const { data } = await supabase
         .from('users')
         .select('roles(name)')
-        .eq('uid', user.id)
+        .eq('id', user.id)
         .single();
       setRole(data?.roles?.name ?? 'anon');
     };

--- a/frontend/src/pages/Confirm.jsx
+++ b/frontend/src/pages/Confirm.jsx
@@ -10,7 +10,7 @@ export default function Confirm() {
       } = await supabase.auth.getUser()
       if (user) {
         await supabase.from('users').insert([
-          { uid: user.id, email: user.email }
+          { id: user.id, email: user.email }
         ])
       }
       window.location.replace('/')

--- a/frontend/supabase-schema.sql
+++ b/frontend/supabase-schema.sql
@@ -4,7 +4,7 @@ create table roles (
 );
 
 create table users (
-  uid uuid primary key references auth.users(id),
+  id uuid primary key references auth.users(id),
   email text,
   role_id integer references roles(id)
 );
@@ -109,4 +109,8 @@ alter table users enable row level security;
 create policy "Allow insert for authenticated users"
 on users for insert
 to authenticated
-using (auth.uid() = uid);
+using (auth.uid() = id);
+
+create policy "Allow access to own user record"
+on users for select
+using (auth.uid() = id);


### PR DESCRIPTION
## Summary
- rename `uid` column to `id` in `users`
- update RLS policies to reference `id`
- insert user with `id` in confirmation page
- query user by `id` in RoleContext

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6875cf9620d8832f91a2e48a244cf48d