### PR TITLE
Implement local role store with logout

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "@supabase/supabase-js": "^2.39.6",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "vite": "^5.2.10",

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,8 +1,19 @@
-import { useRole, usePermissions } from '../RoleContext'
+import { usePermissions } from '../RoleContext'
+import { useRoleStore } from '../store/useRoleStore'
+import { supabase } from '../supabase'
+import { useNavigate } from 'react-router-dom'
 
 export default function Header() {
-  const { role } = useRole()
+  const role = useRoleStore(state => state.role)
+  const setRole = useRoleStore(state => state.setRole)
   const { isKing } = usePermissions()
+  const navigate = useNavigate()
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut()
+    setRole('Anon')
+    navigate('/login')
+  }
 
   return (
     <header className="mb-4 flex justify-between items-center card-royal">
@@ -12,6 +23,7 @@ export default function Header() {
         {isKing() && (
           <button className="btn-royal">Settings</button>
         )}
+        <button onClick={handleLogout} className="btn-royal">Logout</button>
       </div>
     </header>
   )

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState } from 'react'
 import { supabase } from '../supabase'
 import { onAuthStateChange } from '../utils/auth'
+import { useRoleStore } from '../store/useRoleStore'
 
 interface AuthContextProps {
   user: any
@@ -13,15 +14,34 @@ const AuthContext = createContext<AuthContextProps | null>(null)
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<any>(null)
+  const setRole = useRoleStore(state => state.setRole)
+
+  const fetchRole = async (uid: string) => {
+    const { data, error } = await supabase
+      .from('users')
+      .select('roles(name)')
+      .eq('id', uid)
+      .single()
+    if (error) {
+      console.error(error)
+      setRole('Anon')
+      return
+    }
+    setRole((data?.roles as any)?.name ?? 'Anon')
+  }
 
   useEffect(() => {
     const fetchUser = async () => {
       const { data } = await supabase.auth.getUser()
       setUser(data.user)
+      if (data.user) await fetchRole(data.user.id)
+      else setRole('Anon')
     }
     fetchUser()
     const { data: listener } = onAuthStateChange((_event, session) => {
       setUser(session?.user ?? null)
+      if (session?.user) fetchRole(session.user.id)
+      else setRole('Anon')
     })
     return () => {
       listener.subscription.unsubscribe()
@@ -29,8 +49,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [])
 
   const login = async (email: string, password: string) => {
-    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password })
     if (error) throw error
+    if (data.user) await fetchRole(data.user.id)
   }
 
   const register = async (email: string, password: string) => {
@@ -52,6 +73,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logout = async () => {
     const { error } = await supabase.auth.signOut()
     if (error) throw error
+    setRole('Anon')
   }
 
   return (

--- a/frontend/src/store/useRoleStore.ts
+++ b/frontend/src/store/useRoleStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+export type Role = 'King' | 'Chef' | 'Cashier' | 'Anon'
+
+interface RoleStore {
+  role: Role
+  setRole: (role: Role) => void
+}
+
+export const useRoleStore = create<RoleStore>((set) => ({
+  role: 'Anon',
+  setRole: (role) => set({ role })
+}))


### PR DESCRIPTION
## Summary
- add Zustand role store
- refactor RoleContext to use store
- fetch role in AuthProvider and reset on logout
- expose logout button in header
- include zustand dependency

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6875de470610832f96fa368d89b97d63