### PR TITLE
Remove king password check

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,15 +23,9 @@ each task along with the assigned staff member, shift and status. The king can
 add new tasks or delete them, while other staff may only update the status of
 their own tasks.
 
-### Royal Mode
+### Royal Access
 
-Set `VITE_KING_PASSWORD` in your `.env` to enable the hidden admin panel. The SQL below
-creates the log table used for recording royal actions:
-
-```sql
-create table king_activity_log (
-  id uuid default uuid_generate_v4() primary key,
-  action text,
-  timestamp timestamp default now()
-);
-```
+King privileges are determined solely by the `role` field in the `users` table.
+After logging in, the app fetches your role from Supabase and stores it locally
+with Zustand. If your role is `King`, the admin panel and additional controls
+become available automatically.

--- a/frontend/src/pages/Shifts.jsx
+++ b/frontend/src/pages/Shifts.jsx
@@ -1,12 +1,10 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../supabase'
 import { addShift } from '../supabase/shifts'
+import { usePermissions } from '../RoleContext'
 
 export default function Shifts() {
-  const [authorized, setAuthorized] = useState(false)
-  const [keywordOk, setKeywordOk] = useState(false)
-  const [password, setPassword] = useState('')
-  const [keyword, setKeyword] = useState('')
+  const { isKing } = usePermissions()
   const [staff, setStaff] = useState([])
   const [form, setForm] = useState({
     staff_id: '',
@@ -54,37 +52,8 @@ export default function Shifts() {
     }
   }
 
-  if (!authorized) {
-    return (
-      <div className='space-y-2'>
-        <input
-          type='password'
-          className='border border-[#800000] bg-black text-[#FFD700] p-1'
-          placeholder='Password'
-          value={password}
-          onChange={e => setPassword(e.target.value)}
-        />
-        <button className='border border-[#800000] px-2 py-1' onClick={() => setAuthorized(password === 'Ayham')}>
-          Enter
-        </button>
-      </div>
-    )
-  }
-
-  if (!keywordOk) {
-    return (
-      <div className='space-y-2'>
-        <input
-          className='border border-[#800000] bg-black text-[#FFD700] p-1'
-          placeholder='Keyword'
-          value={keyword}
-          onChange={e => setKeyword(e.target.value)}
-        />
-        <button className='border border-[#800000] px-2 py-1' onClick={() => setKeywordOk(keyword === 'إضافة')}>
-          Unlock
-        </button>
-      </div>
-    )
+  if (!isKing()) {
+    return <div>You do not have access to this page.</div>
   }
 
   return (


### PR DESCRIPTION
## Summary
- rely on Supabase `role` to guard king features
- drop password/keyword checks from the Shifts page
- document the new role-based king access in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6875e442f658832fbb6c1280e0ef5b5b