### PR TITLE
Complete role-based access control

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,7 +20,6 @@ import Header from './components/Header'
 import { useRole, usePermissions } from './RoleContext'
 import { useAuth } from './hooks/useAuth'
 import Login from './pages/login'
-import Register from './pages/register'
 
 function App() {
   const { role } = useRole()
@@ -29,9 +28,6 @@ function App() {
   const [page, setPage] = useState('home')
 
   if (!user) {
-    if (location.hash === '#register') {
-      return <Register />
-    }
     return <Login />
   }
 

--- a/frontend/src/RoleContext.tsx
+++ b/frontend/src/RoleContext.tsx
@@ -13,9 +13,9 @@ export function useRole() {
 
 const rolePermissions: Record<Role | string, string[]> = {
   King: ['*'],
-  Admin: ['inventory', 'staff', 'dailyReports', 'orders'],
   Chef: ['inventory', 'dailyReports'],
-  Waiter: ['orders'],
+  Cashier: ['orders'],
+  Anon: [],
 }
 
 export function usePermissions() {

--- a/frontend/src/components/RequireRole.tsx
+++ b/frontend/src/components/RequireRole.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react'
+import { Navigate } from 'react-router-dom'
+import { useRoleStore, Role } from '../store/useRoleStore'
+
+interface Props {
+  roles: Role[]
+  children: ReactNode
+}
+
+export default function RequireRole({ roles, children }: Props) {
+  const role = useRoleStore(s => s.role)
+  if (!roles.includes(role)) {
+    return <Navigate to="/unauthorized" replace />
+  }
+  return <>{children}</>
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -2,49 +2,73 @@ import { useRole, usePermissions } from '../RoleContext'
 
 export default function Sidebar({ onNavigate }) {
   const { role } = useRole()
-  const { isKing } = usePermissions()
+  const { isKing, canAccessPage } = usePermissions()
 
   return (
     <aside className="space-y-2 mr-4 p-4 card-royal">
       <button className="block btn-royal w-full" onClick={() => onNavigate('home')}>
         Home
       </button>
-      <button className="block btn-royal w-full" onClick={() => onNavigate('dailyReports')}>
-        Daily Reports
-      </button>
-      <button className="block btn-royal w-full" onClick={() => onNavigate('inventory')}>
-        Inventory
-      </button>
-      <button className="block btn-royal w-full" onClick={() => onNavigate('staff')}>
-        Staff
-      </button>
-      <button className="block btn-royal w-full" onClick={() => onNavigate('shifts')}>
-        Shifts
-      </button>
-      <button className="block btn-royal w-full" onClick={() => onNavigate('schedule')}>
-        Schedule
-      </button>
-      <button className="block btn-royal w-full" onClick={() => onNavigate('offers')}>
-        Offers
-      </button>
-      <button className="block btn-royal w-full" onClick={() => onNavigate('orders')}>
-        Orders
-      </button>
-      <button className="block btn-royal w-full" onClick={() => onNavigate('notifications')}>
-        Notifications
-      </button>
-      <button className="block btn-royal w-full" onClick={() => onNavigate('ai')}>
-        AI Assistant
-      </button>
-      <button className="block btn-royal w-full" onClick={() => onNavigate('alerts')}>
-        Alerts
-      </button>
-      <button className="block btn-royal w-full" onClick={() => onNavigate('tasks')}>
-        Tasks
-      </button>
-      <button className="block btn-royal w-full" onClick={() => onNavigate('upsell')}>
-        Upsell Center
-      </button>
+      {canAccessPage('dailyReports') && (
+        <button className="block btn-royal w-full" onClick={() => onNavigate('dailyReports')}>
+          Daily Reports
+        </button>
+      )}
+      {canAccessPage('inventory') && (
+        <button className="block btn-royal w-full" onClick={() => onNavigate('inventory')}>
+          Inventory
+        </button>
+      )}
+      {canAccessPage('staff') && (
+        <button className="block btn-royal w-full" onClick={() => onNavigate('staff')}>
+          Staff
+        </button>
+      )}
+      {canAccessPage('shifts') && (
+        <button className="block btn-royal w-full" onClick={() => onNavigate('shifts')}>
+          Shifts
+        </button>
+      )}
+      {canAccessPage('schedule') && (
+        <button className="block btn-royal w-full" onClick={() => onNavigate('schedule')}>
+          Schedule
+        </button>
+      )}
+      {canAccessPage('offers') && (
+        <button className="block btn-royal w-full" onClick={() => onNavigate('offers')}>
+          Offers
+        </button>
+      )}
+      {canAccessPage('orders') && (
+        <button className="block btn-royal w-full" onClick={() => onNavigate('orders')}>
+          Orders
+        </button>
+      )}
+      {canAccessPage('notifications') && (
+        <button className="block btn-royal w-full" onClick={() => onNavigate('notifications')}>
+          Notifications
+        </button>
+      )}
+      {canAccessPage('ai') && (
+        <button className="block btn-royal w-full" onClick={() => onNavigate('ai')}>
+          AI Assistant
+        </button>
+      )}
+      {canAccessPage('alerts') && (
+        <button className="block btn-royal w-full" onClick={() => onNavigate('alerts')}>
+          Alerts
+        </button>
+      )}
+      {canAccessPage('tasks') && (
+        <button className="block btn-royal w-full" onClick={() => onNavigate('tasks')}>
+          Tasks
+        </button>
+      )}
+      {canAccessPage('upsell') && (
+        <button className="block btn-royal w-full" onClick={() => onNavigate('upsell')}>
+          Upsell Center
+        </button>
+      )}
       {isKing() && (
         <>
           <button className="block btn-royal w-full" onClick={() => onNavigate('king')}>Admin Panel</button>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,9 @@ import App from './App'
 import { RoleProvider } from './RoleContext'
 import { AuthProvider } from './hooks/useAuth'
 import Confirm from './pages/Confirm'
+import AddUser from './pages/AddUser'
+import Unauthorized from './pages/Unauthorized'
+import RequireRole from './components/RequireRole'
 import './index.css'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 
@@ -14,6 +17,12 @@ ReactDOM.createRoot(document.getElementById('root')).render(
         <BrowserRouter>
           <Routes>
             <Route path="/confirm" element={<Confirm />} />
+            <Route path="/add-user" element={
+              <RequireRole roles={["King"]}>
+                <AddUser />
+              </RequireRole>
+            } />
+            <Route path="/unauthorized" element={<Unauthorized />} />
             <Route path="*" element={<App />} />
           </Routes>
         </BrowserRouter>

--- a/frontend/src/pages/AddUser.jsx
+++ b/frontend/src/pages/AddUser.jsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+import { supabase } from '../supabase'
+import { useNavigate } from 'react-router-dom'
+
+export default function AddUser() {
+  const navigate = useNavigate()
+  const [form, setForm] = useState({
+    email: '',
+    name: '',
+    role: 'Chef',
+    password: ''
+  })
+
+  const roles = ['Chef', 'Cashier']
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    const { data: authData, error: authError } = await supabase.auth.signUp({
+      email: form.email,
+      password: form.password
+    })
+    if (authError) {
+      alert(authError.message)
+      return
+    }
+    await supabase.from('staff').insert({
+      email: form.email,
+      name: form.name,
+      role: form.role,
+      id: authData.user?.id
+    })
+    navigate(-1)
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center text-[#FFD700]">
+      <form onSubmit={handleSubmit} className="space-y-2 bg-[#0f0f0f] p-4 rounded">
+        <h2 className="text-lg">Add User</h2>
+        <input
+          className="border p-1 text-black w-64"
+          placeholder="Email"
+          name="email"
+          value={form.email}
+          onChange={handleChange}
+        />
+        <input
+          className="border p-1 text-black w-64"
+          placeholder="Name"
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+        />
+        <select
+          name="role"
+          value={form.role}
+          onChange={handleChange}
+          className="border p-1 text-black w-64"
+        >
+          {roles.map(r => <option key={r} value={r}>{r}</option>)}
+        </select>
+        <input
+          className="border p-1 text-black w-64"
+          placeholder="Temp Password"
+          name="password"
+          value={form.password}
+          onChange={handleChange}
+          type="password"
+        />
+        <div className="flex space-x-2">
+          <button type="submit" className="border px-2 py-1">Save</button>
+          <button type="button" className="border px-2 py-1" onClick={() => navigate(-1)}>
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/KingDashboard.tsx
+++ b/frontend/src/pages/KingDashboard.tsx
@@ -1,9 +1,32 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useRole, usePermissions } from '../RoleContext'
+import RequireRole from '../components/RequireRole'
+import { getStaff, updateStaff, deleteStaff } from '../supabase/staff'
+import { useNavigate } from 'react-router-dom'
 
-export default function KingDashboard() {
+function KingDashboardContent() {
   const { role } = useRole()
   const { isKing } = usePermissions()
+  const navigate = useNavigate()
+  const [staff, setStaff] = useState<any[]>([])
+
+  useEffect(() => { if (isKing()) load() }, [])
+
+  async function load() {
+    const data = await getStaff()
+    setStaff(data || [])
+  }
+
+  async function changeRole(id: string, newRole: string) {
+    await updateStaff(id, { role: newRole })
+    load()
+  }
+
+  async function remove(id: string) {
+    if (!confirm('Delete this user?')) return
+    await deleteStaff(id)
+    load()
+  }
 
   if (!isKing()) {
     return <div>You do not have access to this page.</div>
@@ -12,10 +35,57 @@ export default function KingDashboard() {
   return (
     <div className="min-h-screen bg-black p-6 text-[#FFD700] space-y-4">
       <h1 className="text-lg font-semibold">لوحة تحكم الملك</h1>
-      <button className="border-2 border-[#800000] px-3 py-1">تحكم بالجداول</button>
-      <button className="border-2 border-[#800000] px-3 py-1">إعادة ضبط البيانات</button>
-      <div className="border-2 border-[#800000] p-3">أداة التحكم بالمخزون</div>
-      <div className="border-2 border-[#800000] p-3">سجلات اليوم</div>
+      <button
+        className="border-2 border-[#800000] px-3 py-1"
+        onClick={() => navigate('/add-user')}
+      >
+        إضافة مستخدم جديد
+      </button>
+      <table className="w-full text-left border border-[#800000]">
+        <thead>
+          <tr className="border-b border-[#800000]">
+            <th className="p-2">Name</th>
+            <th className="p-2">Email</th>
+            <th className="p-2">Role</th>
+            <th className="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {staff.map(s => (
+            <tr key={s.id} className="border-b border-[#800000]">
+              <td className="p-2">{s.name}</td>
+              <td className="p-2">{s.email}</td>
+              <td className="p-2">
+                <select
+                  value={s.role}
+                  onChange={e => changeRole(s.id, e.target.value)}
+                  className="bg-black border border-[#800000] p-1"
+                >
+                  <option value="Chef">Chef</option>
+                  <option value="Cashier">Cashier</option>
+                  <option value="King">King</option>
+                </select>
+              </td>
+              <td className="p-2">
+                <button
+                  className="border px-2"
+                  onClick={() => remove(s.id)}
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
+  )
+}
+
+export default function KingDashboard() {
+  return (
+    <RequireRole roles={["King"]}>
+      <KingDashboardContent />
+    </RequireRole>
   )
 }

--- a/frontend/src/pages/StaffPage.jsx
+++ b/frontend/src/pages/StaffPage.jsx
@@ -1,10 +1,13 @@
 import StaffTable from '../components/StaffTable'
+import RequireRole from '../components/RequireRole'
 
 export default function StaffPage() {
   return (
-    <div className="space-y-4 text-[#FFD700]">
-      <h2 className="text-xl font-bold">Staff Members</h2>
-      <StaffTable />
-    </div>
+    <RequireRole roles={["King"]}>
+      <div className="space-y-4 text-[#FFD700]">
+        <h2 className="text-xl font-bold">Staff Members</h2>
+        <StaffTable />
+      </div>
+    </RequireRole>
   )
 }

--- a/frontend/src/pages/Unauthorized.jsx
+++ b/frontend/src/pages/Unauthorized.jsx
@@ -1,0 +1,7 @@
+export default function Unauthorized() {
+  return (
+    <div className="min-h-screen flex items-center justify-center text-[#FFD700]">
+      <h1 className="text-2xl">غير مصرح لك بالدخول</h1>
+    </div>
+  )
+}

--- a/frontend/src/pages/inventory/InventoryPage.tsx
+++ b/frontend/src/pages/inventory/InventoryPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { useRole, usePermissions } from '../../RoleContext'
+import { useRole } from '../../RoleContext'
+import RequireRole from '../../components/RequireRole'
 import { getInventory } from '../../supabase/inventory'
 
 interface InventoryItem {
@@ -11,9 +12,8 @@ interface InventoryItem {
   created_at: string
 }
 
-export default function InventoryPage() {
+function InventoryContent() {
   const { role } = useRole()
-  const { isKing } = usePermissions()
   const [items, setItems] = useState<InventoryItem[]>([])
   const [search, setSearch] = useState('')
   const [lowOnly, setLowOnly] = useState(false)
@@ -32,11 +32,6 @@ export default function InventoryPage() {
     fetchData()
   }, [])
 
-  if (!isKing()) {
-    return (
-      <div className="text-[#FFD700]">You do not have access to this page.</div>
-    )
-  }
 
   const filtered = items
     .filter((i) => i.item_name.toLowerCase().includes(search.toLowerCase()))
@@ -97,5 +92,13 @@ export default function InventoryPage() {
         ))}
       </div>
     </div>
+  )
+}
+
+export default function InventoryPage() {
+  return (
+    <RequireRole roles={["King", "Chef"]}>
+      <InventoryContent />
+    </RequireRole>
   )
 }

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -38,9 +38,6 @@ export default function Login() {
         <button className="bg-gold text-black px-4 py-2 rounded hover:scale-105 transition-transform">
           Login
         </button>
-        <p className="mt-2 text-sm">
-          No account? <a href="#register" className="text-gold underline" onClick={() => location.hash = 'register'}>Register</a>
-        </p>
       </form>
     </div>
   )


### PR DESCRIPTION
## Summary
- store user role from the `staff` table in Zustand on login
- provide a `RequireRole` wrapper for protecting pages
- add King management dashboard with user controls
- add page for adding users
- restrict sidebar links by role
- remove self‑registration link
- add route protection and unauthorized page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875eaccfde4832fbe388859632f164f