### PR TITLE
Load role from public.users on login

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,7 +25,7 @@ their own tasks.
 
 ### Royal Access
 
-King privileges are determined solely by the `role` field in the `users` table.
-After logging in, the app fetches your role from Supabase and stores it locally
-with Zustand. If your role is `King`, the admin panel and additional controls
+King privileges are determined by the `role` stored in **public.users**.
+After logging in, the app reads this value from Supabase and places it directly
+into Zustand. If your role is `King`, the admin panel and additional controls
 become available automatically.

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -17,8 +17,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const fetchRole = async (email: string) => {
     const { data, error } = await supabase
-      .from('staff')
-      .select('role')
+      .from('users')
+      .select('roles(name)')
       .eq('email', email)
       .single()
     if (error) {
@@ -26,7 +26,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setRole('Anon')
       return
     }
-    setRole((data as any)?.role ?? 'Anon')
+    setRole((data as any)?.roles?.name ?? 'Anon')
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- adjust docs for role source
- fetch role from `public.users` instead of the `staff` table

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875ef14f560832f86a5fb1d569701dc