### PR TITLE
feat: add responsive footer

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,6 +17,7 @@ import KingControlCenter from './pages/KingControlCenter'
 import ConfigSettings from './pages/ConfigSettings'
 import Sidebar from './components/Sidebar'
 import Header from './components/Header'
+import Footer from './components/layout/footer'
 import { useRole, usePermissions } from './RoleContext'
 import { useAuth } from './hooks/useAuth'
 import Login from './pages/login'
@@ -71,12 +72,15 @@ function App() {
   }
 
   return (
-    <div className='p-6 min-h-screen flex'>
-      <Sidebar onNavigate={setPage} />
-      <div className='flex-1'>
-        <Header />
-        {content}
+    <div className='p-6 min-h-screen flex flex-col'>
+      <div className='flex flex-1'>
+        <Sidebar onNavigate={setPage} />
+        <div className='flex-1 flex flex-col'>
+          <Header />
+          <div className='flex-1'>{content}</div>
+        </div>
       </div>
+      <Footer />
     </div>
   )
 }

--- a/frontend/src/components/layout/footer.tsx
+++ b/frontend/src/components/layout/footer.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+const links = [
+  { name: 'Home', href: '#' },
+  { name: 'Services', href: '#' },
+  { name: 'About', href: '#' },
+  { name: 'Contact', href: '#' },
+]
+
+export default function Footer() {
+  return (
+    <footer className="bg-[#0f0f0f] text-gray-300 py-12 px-6 mt-24 font-sans">
+      <div className="max-w-7xl mx-auto flex flex-col items-center gap-8 md:flex-row md:justify-between">
+        <div className="text-lg font-semibold">Techno Tech</div>
+        <nav className="flex flex-col items-center gap-4 md:flex-row md:gap-6">
+          {links.map(link => (
+            <a
+              key={link.name}
+              href={link.href}
+              className="hover:text-white transition-colors"
+            >
+              {link.name}
+            </a>
+          ))}
+        </nav>
+        <p className="text-sm text-gray-400 text-center md:text-right">
+          © 2025 Techno Tech Inc. All rights reserved.
+        </p>
+      </div>
+    </footer>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add a responsive footer layout component with quick links and copyright
- include footer in main App layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68915d8928d4832f971c71054a203fab